### PR TITLE
LoadingIndicatorのレスポンシブ対応

### DIFF
--- a/src/app/(main)/MainLayout.module.css
+++ b/src/app/(main)/MainLayout.module.css
@@ -1,17 +1,22 @@
 .container {
-	max-height: calc(100vh - 212px);
+	max-height: calc(100vh - 220px);
 	display: block grid;
 	grid-template-columns: 275px 1fr;
 	gap: 20px;
 	padding-inline: 20px;
-	padding-block: 0 17px;
 
 	@media (width < 1024px) {
+		max-height: calc(100vh - 215px);
 		grid-template-columns: 1fr;
 	}
 
+	@media (width < 768px) {
+		max-height: calc(100vh - 210px);
+	}
+
 	@media (width < 640px) {
-		padding-inline: 12px;
+		max-height: calc(100vh - 170px);
+		padding-inline: 7px;
 	}
 }
 

--- a/src/app/(main)/explore/ExplorePage.module.css
+++ b/src/app/(main)/explore/ExplorePage.module.css
@@ -49,3 +49,15 @@
 		overflow-y: scroll;
 	}
 }
+
+.loading-indicator {
+	font-size: 1.125rem;
+
+	@media (width < 768px) {
+		font-size: 1rem;
+	}
+
+	@media (width < 640px) {
+		font-size: 0.875rem;
+	}
+}

--- a/src/app/(main)/explore/page.tsx
+++ b/src/app/(main)/explore/page.tsx
@@ -16,7 +16,7 @@ const ExplorePage = () => {
 				<Suspense
 					fallback={
 						<div className="grid place-items-center pt-4">
-							<LoadingIndicator text="読み込み中" fontSize="1.125rem" />
+							<LoadingIndicator text="読み込み中" className={styles["loading-indicator"]} />
 						</div>
 					}
 				>

--- a/src/app/Home.module.css
+++ b/src/app/Home.module.css
@@ -15,11 +15,21 @@
 .crown-container {
 	width: 50px;
 	height: auto;
-	margin-inline-start: 282px;
+	margin-inline-start: 256px;
 	filter: drop-shadow(0 0 2px color-mix(in srgb, var(--color-primary-orange), transparent 10%))
 		drop-shadow(0 0 2px color-mix(in srgb, var(--color-primary-orange), transparent 50%))
 		drop-shadow(0 0 2px color-mix(in srgb, var(--color-primary-orange), transparent 50%))
 		drop-shadow(0 0 2px color-mix(in srgb, var(--color-primary-orange), transparent 50%))
 		drop-shadow(0 0 2px color-mix(in srgb, var(--color-primary-orange), transparent 50%))
 		drop-shadow(0 0 2px color-mix(in srgb, var(--color-primary-orange), transparent 50%));
+
+	@media (width < 1280px) {
+		width: 60px;
+		margin-inline-start: 0;
+		margin-block-end: 15px;
+	}
+
+	@media (width < 768px) {
+		width: 40px;
+	}
 }

--- a/src/components/common/audio/audio-player/AudioPlayer.module.css
+++ b/src/components/common/audio/audio-player/AudioPlayer.module.css
@@ -1,3 +1,8 @@
+.audio-button-container {
+	display: block grid;
+	place-items: center;
+}
+
 .audio-button {
 	width: 50px;
 	height: auto;
@@ -6,9 +11,12 @@
 	filter: drop-shadow(0px 1px 1px rgb(0 0 0 / 80%));
 	transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 
-	@media (width < 640px) {
+	@media (width < 1024px) {
 		width: 45px;
-		height: 45px;
+	}
+
+	@media (width < 768px) {
+		width: 40px;
 	}
 }
 

--- a/src/components/common/audio/audio-player/AudioPlayer.tsx
+++ b/src/components/common/audio/audio-player/AudioPlayer.tsx
@@ -61,7 +61,7 @@ const AudioPlayer = memo(({ src, className = "audio-button", volume = 1 }: Audio
 		<div className={styles["audio-button-container"]}>
 			<button
 				onClick={handleClick}
-				className={`hidden lg:block md:sticky md:inset-0 ${styles["audio-button"]} ${className}`}
+				className={`${styles["audio-button"]} ${className}`}
 				aria-label={isMuted ? "Unmute" : "Mute"}
 			>
 				{isMuted ? (

--- a/src/components/common/container/CommonContainer.module.css
+++ b/src/components/common/container/CommonContainer.module.css
@@ -7,4 +7,8 @@
 
 .border {
 	border: 5px solid var(--color-primary-white);
+
+	@media (width < 640px) {
+		border: 3px solid var(--color-primary-white);
+	}
 }

--- a/src/components/layout/header/Header.module.css
+++ b/src/components/layout/header/Header.module.css
@@ -10,8 +10,13 @@
 	padding-block: 20px;
 	padding-inline: 20px;
 
+	&:has(.home-header-container) {
+		padding-block-end: 0;
+	}
+
 	@media (width < 640px) {
-		padding-inline: 12px;
+		padding-inline: 7px;
+		padding-block: 7px;
 	}
 }
 
@@ -38,12 +43,17 @@
 	padding-inline: 1.875rem;
 	padding-block: 0.875rem;
 
+	@media (width < 1024px) {
+		padding-inline: 1.25rem;
+	}
+
 	@media (width < 768px) {
 		padding-inline: 1.25rem;
 	}
 
 	@media (width < 640px) {
-		padding-inline: 1.25rem;
+		padding-inline: 1rem;
+		padding-block: 0.75rem;
 	}
 }
 
@@ -84,7 +94,7 @@
 	align-items: center;
 	gap: 25px;
 
-	@media (width < 640px) {
+	@media (width < 768px) {
 		gap: 15px;
 	}
 }

--- a/src/features/connection/components/connection-auth-section/ConnectionAuthSection.module.css
+++ b/src/features/connection/components/connection-auth-section/ConnectionAuthSection.module.css
@@ -118,3 +118,15 @@
 	align-items: center;
 	gap: 6px;
 }
+
+.loading-indicator {
+	font-size: 1.125rem;
+
+	@media (width < 768px) {
+		font-size: 1rem;
+	}
+
+	@media (width < 640px) {
+		font-size: 0.875rem;
+	}
+}

--- a/src/features/connection/components/connection-auth-section/ConnectionAuthSection.tsx
+++ b/src/features/connection/components/connection-auth-section/ConnectionAuthSection.tsx
@@ -60,13 +60,13 @@ const ConnectionAuthSection: React.FC<ConnectionAuthSectionProps> = ({
 					<span>Zennユーザー名</span>
 					<strong className="text-[#ffc630]">(必須)</strong>
 				</label>
-				<div className="flex gap-3 opacity-40 select-none">
+				<div className="flex sm:gap-2 gap-1 opacity-40 select-none">
 					<input
 						id="zenn-username"
 						type="text"
 						value=""
 						onChange={() => {}}
-						className="flex-1 border-[3px] border-gray-400 bg-white rounded px-3 py-2 text-black cursor-not-allowed"
+						className="flex-1 border-[3px] border-gray-400 bg-white rounded px-3 py-2 text-black cursor-not-allowed min-w-0"
 						placeholder="例: aoyamadev"
 						disabled
 					/>
@@ -74,11 +74,15 @@ const ConnectionAuthSection: React.FC<ConnectionAuthSectionProps> = ({
 						onClick={() => updateUserProfile()}
 						className={`${styles["connect-button"]} ${
 							!loading && zennUsername ? styles["active"] : ""
-						} ${loading || !zennUsername ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+						} ${loading || !zennUsername ? "opacity-50 cursor-not-allowed" : "cursor-pointer"} shrink-0`}
 						disabled={loading || !zennUsername}
 					>
-						<div className={`${styles["connect-button-content"]}`}>
-							{loading ? <LoadingIndicator text="連携中" /> : "連携"}
+						<div className={`${styles["connect-button-content"]} whitespace-nowrap`}>
+							{loading ? (
+								<LoadingIndicator text="連携中" className={styles["loading-indicator"]} />
+							) : (
+								"連携"
+							)}
 						</div>
 					</button>
 				</div>

--- a/src/features/connection/components/connection-button-group/ConnectionButtonGroup.module.css
+++ b/src/features/connection/components/connection-button-group/ConnectionButtonGroup.module.css
@@ -113,3 +113,15 @@
 		text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
 	}
 }
+
+.loading-indicator {
+	font-size: 1.125rem;
+
+	@media (width < 768px) {
+		font-size: 1rem;
+	}
+
+	@media (width < 640px) {
+		font-size: 0.875rem;
+	}
+}

--- a/src/features/connection/components/connection-button-group/ConnectionButtonGroup.tsx
+++ b/src/features/connection/components/connection-button-group/ConnectionButtonGroup.tsx
@@ -52,8 +52,7 @@ const ConnectionButtonGroup: React.FC<ConnectionButtonGroupProps> = ({
 					{loading ? (
 						<LoadingIndicator
 							text="同期中"
-							className={styles["sync-button-text"]}
-							fontSize="0.875rem"
+							className={`${styles["sync-button-text"]} ${styles["loading-indicator"]}`}
 						/>
 					) : (
 						<span className={styles["sync-button-text"]}>同期する</span>

--- a/src/features/connection/components/connection-message-display/ConnectionMessageDisplay.module.css
+++ b/src/features/connection/components/connection-message-display/ConnectionMessageDisplay.module.css
@@ -27,3 +27,15 @@
 .success-message {
 	background-color: var(--bg-color-message-success);
 }
+
+.loading-indicator {
+	font-size: 1.125rem;
+
+	@media (width < 768px) {
+		font-size: 1rem;
+	}
+
+	@media (width < 640px) {
+		font-size: 0.875rem;
+	}
+}

--- a/src/features/connection/components/connection-message-display/ConnectionMessageDisplay.tsx
+++ b/src/features/connection/components/connection-message-display/ConnectionMessageDisplay.tsx
@@ -26,7 +26,11 @@ const ConnectionMessageDisplay: React.FC<ConnectionMessageDisplayProps> = ({
 		<>
 			{error && (
 				<strong className={styles["error-message"]}>
-					{isLoadingError ? <LoadingIndicator text={loadingMessage} fontSize="0.875rem" /> : error}
+					{isLoadingError ? (
+						<LoadingIndicator text={loadingMessage} className={styles["loading-indicator"]} />
+					) : (
+						error
+					)}
 				</strong>
 			)}
 			{!error && success && <p className={styles["success-message"]}>{success}</p>}

--- a/src/features/connection/components/connection-page-client/ConnectionPageClient.module.css
+++ b/src/features/connection/components/connection-page-client/ConnectionPageClient.module.css
@@ -1,3 +1,18 @@
+.title-bg {
+	background-color: var(--color-primary-dark-gray);
+	width: calc(100% - 62px);
+	height: 20px;
+	position: absolute;
+	top: 24px;
+	left: 50%;
+	transform: translateX(-50%);
+	z-index: 10;
+
+	@media (width < 1024px) {
+		width: calc(100% - 30px);
+	}
+}
+
 .profile-title {
 	position: absolute;
 	top: 8px;
@@ -26,6 +41,10 @@
 	border-radius: var(--border-radius-small);
 	padding-block-start: 40px;
 
+	@media (width < 1024px) {
+		overflow-y: scroll;
+	}
+
 	@media (width < 768px) {
 		padding-block-start: 25px;
 	}
@@ -38,6 +57,10 @@
 		"header"
 		"info";
 	overflow-y: auto;
+
+	@media (width < 1024px) {
+		overflow-y: scroll;
+	}
 }
 
 .profile-info-header {
@@ -60,6 +83,10 @@
 	padding-block: 25px;
 	padding-inline: 20px;
 	overflow-y: scroll;
+
+	@media (width < 1024px) {
+		overflow-y: visible;
+	}
 }
 
 .connection-info-zenn {
@@ -76,4 +103,16 @@
 	grid-area: message;
 	display: block grid;
 	place-content: center;
+}
+
+.loading-indicator {
+	font-size: 1.125rem;
+
+	@media (width < 768px) {
+		font-size: 1rem;
+	}
+
+	@media (width < 640px) {
+		font-size: 0.875rem;
+	}
 }

--- a/src/features/connection/components/connection-page-client/ConnectionPageClient.tsx
+++ b/src/features/connection/components/connection-page-client/ConnectionPageClient.tsx
@@ -136,13 +136,13 @@ export default function ConnectionPageClient() {
 
 	return (
 		<>
+			<div className={styles["title-bg"]}></div>
 			<h1 className={`${styles["profile-title"]}`}>連携</h1>
 			<div className={`${styles["profile-container"]}`}>
 				{!isLoaded ? (
 					<LoadingIndicator
 						text="読み込み中"
-						className="px-4 pb-[40px] text-center"
-						fontSize="1.125rem"
+						className={`${styles["loading-indicator"]} px-4 pb-[40px] text-center`}
 					/>
 				) : !user ? (
 					<Connection.ConnectionAuthSection
@@ -160,7 +160,10 @@ export default function ConnectionPageClient() {
 
 						<div className={styles["connection-info-container"]}>
 							{!isZennInfoLoaded ? (
-								<LoadingIndicator text="読み込み中" className="p-4 text-center" />
+								<LoadingIndicator
+									text="読み込み中"
+									className={`${styles["loading-indicator"]} p-4 text-center`}
+								/>
 							) : displayUser?.zennUsername ? (
 								<>
 									<div className={styles["connection-info-zenn"]}>

--- a/src/features/connection/components/connection-zenn-form/ConnectionZennForm.module.css
+++ b/src/features/connection/components/connection-zenn-form/ConnectionZennForm.module.css
@@ -34,6 +34,18 @@
 	gap: 6px;
 }
 
+.loading-indicator {
+	font-size: 1.125rem;
+
+	@media (width < 768px) {
+		font-size: 1rem;
+	}
+
+	@media (width < 640px) {
+		font-size: 0.875rem;
+	}
+}
+
 .zenn-logo-sm {
 	width: 16px;
 	height: 16px;

--- a/src/features/connection/components/connection-zenn-form/ConnectionZennForm.tsx
+++ b/src/features/connection/components/connection-zenn-form/ConnectionZennForm.tsx
@@ -82,7 +82,7 @@ const ConnectionZennForm = memo<ConnectionZennFormProps>(function ConnectionZenn
 			) : (
 				<div className="text-center mt-[12px]">
 					{loading && isZennInfoLoaded ? (
-						<LoadingIndicator text="連携中" />
+						<LoadingIndicator text="連携中" className={styles["loading-indicator"]} />
 					) : (
 						<p>Zennと連携が必要です。</p>
 					)}

--- a/src/features/explore/components/explore-page-client/ExplorePageClient.module.css
+++ b/src/features/explore/components/explore-page-client/ExplorePageClient.module.css
@@ -201,3 +201,15 @@
 		transform: scale(1);
 	}
 }
+
+.loading-indicator {
+	font-size: 1.125rem;
+
+	@media (width < 768px) {
+		font-size: 1rem;
+	}
+
+	@media (width < 640px) {
+		font-size: 0.875rem;
+	}
+}

--- a/src/features/explore/components/explore-page-client/ExplorePageClient.tsx
+++ b/src/features/explore/components/explore-page-client/ExplorePageClient.tsx
@@ -24,7 +24,7 @@ const ExploreArticleAnalysis = dynamic(
 					height: "100%",
 				}}
 			>
-				<LoadingIndicator text="読み込み中" fontSize="1.125rem" />
+				<LoadingIndicator text="読み込み中" className={styles["loading-indicator"]} />
 			</div>
 		),
 	}
@@ -160,7 +160,7 @@ const ExplorePageClient = () => {
 
 					{!isLoaded || !isZennInfoLoaded ? (
 						<div className="grid place-items-center px-4">
-							<LoadingIndicator text="読み込み中" fontSize="0.875rem" />
+							<LoadingIndicator text="読み込み中" className={styles["loading-indicator"]} />
 						</div>
 					) : !isGuestUser ? (
 						<div className={styles["explore-analysis-controls"]}>

--- a/src/features/home/components/home-animated-title/HomeAnimatedTitle.module.css
+++ b/src/features/home/components/home-animated-title/HomeAnimatedTitle.module.css
@@ -3,6 +3,10 @@
 	place-items: center;
 	place-self: end center;
 	gap: 35px;
+
+	@media (width < 1280px) {
+		gap: 25px;
+	}
 }
 
 .title {
@@ -12,7 +16,7 @@
 	line-height: var(--leading-none);
 	letter-spacing: -0.065em;
 	color: var(--color-primary-yellow);
-	font-size: 10rem;
+	font-size: 9rem;
 	text-align: center;
 	text-shadow:
 		0px 0px 5px var(--color-primary-orange),
@@ -23,6 +27,20 @@
 		0px 0px 10px var(--color-primary-orange),
 		0px 0px 15px var(--color-primary-orange),
 		0px 0px 15px var(--color-primary-orange);
+
+	@media (width < 1280px) {
+		flex-direction: column;
+		gap: 15px;
+		font-size: 7rem;
+	}
+
+	@media (width < 768px) {
+		font-size: 5rem;
+	}
+
+	@media (width < 640px) {
+		font-size: 4.5rem;
+	}
 }
 
 .subtitle {
@@ -36,4 +54,12 @@
 		0px 0px 5px var(--color-primary-orange),
 		0px 0px 10px var(--color-primary-orange),
 		0px 0px 10px var(--color-primary-orange);
+
+	@media (width < 1280px) {
+		font-size: 1.25rem;
+	}
+
+	@media (width < 768px) {
+		font-size: 1.125rem;
+	}
 }

--- a/src/features/home/components/home-start-button/HomeStartButton.module.css
+++ b/src/features/home/components/home-start-button/HomeStartButton.module.css
@@ -2,6 +2,14 @@
 	display: block grid;
 	place-items: center;
 	margin-block-start: 135px;
+
+	@media (width < 1280px) {
+		margin-block-start: 70px;
+	}
+
+	@media (width < 768px) {
+		margin-block-start: 50px;
+	}
 }
 
 .start-btn {
@@ -9,6 +17,14 @@
 	height: auto;
 	position: relative;
 	filter: drop-shadow(0px 1px 1px rgb(0 0 0 / 80%));
+
+	@media (width < 1280px) {
+		width: 150px;
+	}
+
+	@media (width < 768px) {
+		width: 130px;
+	}
 }
 
 .start-btn-image {
@@ -21,6 +37,14 @@
 	left: 0px;
 	height: 62px;
 	opacity: 0;
+
+	@media (width < 1280px) {
+		height: 56px;
+	}
+
+	@media (width < 768px) {
+		height: 48.5px;
+	}
 }
 
 .start-btn:hover .start-btn-image {

--- a/src/features/logs/components/logs-list/LogsList.module.css
+++ b/src/features/logs/components/logs-list/LogsList.module.css
@@ -30,3 +30,15 @@
 	display: block grid;
 	place-items: center;
 }
+
+.loading-indicator {
+	font-size: 1.125rem;
+
+	@media (width < 768px) {
+		font-size: 1rem;
+	}
+
+	@media (width < 640px) {
+		font-size: 0.875rem;
+	}
+}

--- a/src/features/logs/components/logs-list/LogsList.tsx
+++ b/src/features/logs/components/logs-list/LogsList.tsx
@@ -25,7 +25,7 @@ const LogsList = () => {
 			{loading ? (
 				<li className={styles["logs-page-list-item"]}>
 					<div className={styles["logs-page-list-item-loading-text"]}>
-						<LoadingIndicator text="読み込み中" fontSize="0.875rem" />
+						<LoadingIndicator text="読み込み中" className={styles["loading-indicator"]} />
 					</div>
 				</li>
 			) : logs.length === 0 ? (

--- a/src/features/strength/components/strength-log-info/StrengthLogInfo.module.css
+++ b/src/features/strength/components/strength-log-info/StrengthLogInfo.module.css
@@ -139,3 +139,15 @@
 		left: 0;
 	}
 }
+
+.loading-indicator {
+	font-size: 1.125rem;
+
+	@media (width < 768px) {
+		font-size: 1rem;
+	}
+
+	@media (width < 640px) {
+		font-size: 0.875rem;
+	}
+}

--- a/src/features/strength/components/strength-log-info/StrengthLogInfo.tsx
+++ b/src/features/strength/components/strength-log-info/StrengthLogInfo.tsx
@@ -156,7 +156,7 @@ const StrengthLogInfo = () => {
 								{loading ? (
 									<li className={styles["strength-log-item"]}>
 										<div className={styles["strength-log-loading-text"]}>
-											<LoadingIndicator text="読み込み中" fontSize="0.875rem" />
+											<LoadingIndicator text="読み込み中" className={styles["loading-indicator"]} />
 										</div>
 									</li>
 								) : (

--- a/src/features/strength/components/strength-title-info/StrengthTitleInfo.module.css
+++ b/src/features/strength/components/strength-title-info/StrengthTitleInfo.module.css
@@ -203,3 +203,15 @@
 		left: 0;
 	}
 }
+
+.loading-indicator {
+	font-size: 1.125rem;
+
+	@media (width < 768px) {
+		font-size: 1rem;
+	}
+
+	@media (width < 640px) {
+		font-size: 0.875rem;
+	}
+}

--- a/src/features/strength/components/strength-title-info/StrengthTitleInfo.tsx
+++ b/src/features/strength/components/strength-title-info/StrengthTitleInfo.tsx
@@ -180,7 +180,7 @@ const StrengthTitleInfo = () => {
 								className={`${styles["strength-title-detail-content"]} ${getCurrentTitleClass()}`}
 							>
 								{isLoadingTitle || !isReady ? (
-									<LoadingIndicator text="読み込み中" fontSize="1.125rem" />
+									<LoadingIndicator text="読み込み中" className={styles["loading-indicator"]} />
 								) : (
 									<h3 className={styles["strength-title-detail-text"]}>{getLatestTitle()}</h3>
 								)}

--- a/src/features/title/components/title-page-client/TitlePageClient.module.css
+++ b/src/features/title/components/title-page-client/TitlePageClient.module.css
@@ -52,3 +52,15 @@
 		margin-inline: auto;
 	}
 }
+
+.loading-indicator {
+	font-size: 1.125rem;
+
+	@media (width < 768px) {
+		font-size: 1rem;
+	}
+
+	@media (width < 640px) {
+		font-size: 0.875rem;
+	}
+}

--- a/src/features/title/components/title-page-client/TitlePageClient.tsx
+++ b/src/features/title/components/title-page-client/TitlePageClient.tsx
@@ -61,7 +61,7 @@ const TitlePageClient = () => {
 		return (
 			<div className={`${styles["title-page-container"]}`}>
 				<div className="text-sm sm:text-base grid place-items-center h-full bg-[#1a1a1a] px-[10px] py-[40px]">
-					<LoadingIndicator text="読み込み中" fontSize="1rem" />
+					<LoadingIndicator text="読み込み中" className={styles["loading-indicator"]} />
 				</div>
 			</div>
 		);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -193,6 +193,11 @@
 			"Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
 		font-weight: 600;
 		font-style: normal;
+
+		@media (width < 640px) {
+			padding-inline: 7px;
+			padding-block-start: 7px;
+		}
 	}
 
 	main {


### PR DESCRIPTION
## 概要
LoadingIndicatorコンポーネントにレスポンシブなフォントサイズを適用し、アプリケーション全体でスタイルを統一しました。

## 変更点
- .loading-indicator クラスを定義し、各CSSモジュールに追加
- 画面幅 768px 未満、640px 未満でのフォントサイズ調整を追加
- 各コンポーネントで fontSize プロパティの直書きを廃止し、クラスによる指定に変更

## 関連コンポーネント
- ExplorePageClient
- StrengthLogInfo
- StrengthTitleInfo
- LogsList
- TitlePageClient
- ConnectionPageClient
- ConnectionMessageDisplay
- ConnectionAuthSection
- ConnectionZennForm
- ConnectionButtonGroup