### PR TITLE
トップページのアニメーション同期修正

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import "../styles/globals.css";
 import { ControlViewport } from "@/components/layout/control-viewport/ControlViewport";
 import { AudioProvider } from "@/contexts/AudioContext";
 import { SignOutHandler } from "@/contexts/SignOutHandler";
+import { HomeAnimationProvider } from "@/features/home/contexts/HomeAnimationContext";
 
 const dotGothic16 = DotGothic16({
 	weight: "400",
@@ -54,12 +55,14 @@ export default function RootLayout({
 					<SignOutHandler>
 						<AudioProvider>
 							<HeroProvider>
-								<CommonContainer>
-									<ControlViewport />
-									<Header />
-									{children}
-									<Footer />
-								</CommonContainer>
+								<HomeAnimationProvider>
+									<CommonContainer>
+										<ControlViewport />
+										<Header />
+										{children}
+										<Footer />
+									</CommonContainer>
+								</HomeAnimationProvider>
 							</HeroProvider>
 						</AudioProvider>
 					</SignOutHandler>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,6 @@ import dynamic from "next/dynamic";
 import styles from "./Home.module.css";
 import * as Home from "@/features/home/components";
 import * as Hero from "@/features/hero/components";
-import { HomeAnimationProvider } from "@/features/home/contexts/HomeAnimationContext";
 
 // Motion使用コンポーネントを動的インポート（Client Bundleを最小化）
 const HomeAnimatedTitle = dynamic(
@@ -14,17 +13,15 @@ const HomeAnimatedCrown = dynamic(
 
 export default function HomePage() {
 	return (
-		<HomeAnimationProvider>
-			<main className={`${styles["main"]}`}>
-				<Hero.HeroBg />
-				<div className={`${styles["main-container"]}`}>
-					<div className={`${styles["crown-container"]}`}>
-						<HomeAnimatedCrown />
-					</div>
-					<HomeAnimatedTitle />
-					<Home.HomeStartButton />
+		<main className={`${styles["main"]}`}>
+			<Hero.HeroBg />
+			<div className={`${styles["main-container"]}`}>
+				<div className={`${styles["crown-container"]}`}>
+					<HomeAnimatedCrown />
 				</div>
-			</main>
-		</HomeAnimationProvider>
+				<HomeAnimatedTitle />
+				<Home.HomeStartButton />
+			</div>
+		</main>
 	);
 }

--- a/src/components/layout/footer/Footer.tsx
+++ b/src/components/layout/footer/Footer.tsx
@@ -3,12 +3,28 @@
 import { siteData } from "@/consts/site";
 import styles from "./Footer.module.css";
 import { usePathname } from "next/navigation";
+import { motion } from "motion/react";
+import { useHomeAnimation } from "@/features/home/contexts/HomeAnimationContext";
 
 export const Footer = () => {
 	const pathname = usePathname();
 	const isHome = pathname === "/";
+
+	// HomeAnimationContextから値を取得（プロバイダー外の場合はデフォルト値を返す）
+	const { isImageVisible, isFirstVisit } = useHomeAnimation();
+
+	// ホーム画面かつ初回訪問時のみアニメーションを適用
+	const shouldAnimate = isHome;
+
 	return (
-		<footer className={`${styles["footer"]}`}>
+		<motion.footer
+			className={`${styles["footer"]}`}
+			initial={shouldAnimate ? { opacity: 0 } : { opacity: 1 }}
+			animate={shouldAnimate ? { opacity: isImageVisible ? 1 : 0 } : { opacity: 1 }}
+			transition={
+				shouldAnimate ? { duration: isFirstVisit ? 1.75 : 0, ease: "easeInOut" } : { duration: 0 }
+			}
+		>
 			<div
 				className={`${styles["footer-container"]} ${
 					isHome ? styles["home-position"] : styles["other-position"]
@@ -20,6 +36,6 @@ export const Footer = () => {
 					</small>
 				</div>
 			</div>
-		</footer>
+		</motion.footer>
 	);
 };

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -9,6 +9,8 @@ import HamburgerMenu from "@/components/elements/hamburger-menu/HamburgerMenu";
 import Gnav from "@/components/layout/gnav/Gnav";
 import styles from "./Header.module.css";
 import Crown from "@/components/common/crown/Crown";
+import { motion } from "motion/react";
+import { useHomeAnimation } from "@/features/home/contexts/HomeAnimationContext";
 
 export const Header = () => {
 	const pathname = usePathname();
@@ -18,8 +20,25 @@ export const Header = () => {
 		volume: 0.5,
 	});
 
+	// Audio player animation control
+	const { isImageVisible, isFirstVisit } = useHomeAnimation();
+	const isHome = pathname === "/";
+	const shouldAnimateAudio = isHome;
+
 	// audioPlayer の定義をここに移動
-	const audioPlayer = <AudioPlayer src="/audio/outputquest-theme-song.mp3" volume={0.5} />;
+	const audioPlayer = (
+		<motion.div
+			initial={shouldAnimateAudio ? { opacity: 0 } : { opacity: 1 }}
+			animate={shouldAnimateAudio ? { opacity: isImageVisible ? 1 : 0 } : { opacity: 1 }}
+			transition={
+				shouldAnimateAudio
+					? { duration: isFirstVisit ? 1.75 : 0, ease: "easeInOut" }
+					: { duration: 0 }
+			}
+		>
+			<AudioPlayer src="/audio/outputquest-theme-song.mp3" volume={0.5} />
+		</motion.div>
+	);
 
 	const toggleMenu = () => {
 		setIsMenuOpen(!isMenuOpen);


### PR DESCRIPTION
## 概要
トップページのオープニングアニメーションにおいて、音声ボタン（ヘッダー）とコピーライト（フッター）が最初から表示されていた問題を修正しました。
これらがメインコンテンツ（背景画像・Startボタン）のフェードインと同時に表示されるよう同期させ、より没入感のあるオープニング体験を実現しました。

## 変更点
- **HomeAnimationProviderの移動:** `src/app/page.tsx` から `src/app/layout.tsx` へ移動し、ヘッダー・フッターもアニメーションコンテキストの管理下に置きました。
- **ヘッダー（AudioPlayer）:** ホーム画面かつ初回訪問時のみ、`isImageVisible` フラグに連動してフェードインするように変更。
- **フッター:** `motion.footer` に変更し、同様にホーム画面かつ初回訪問時のみフェードインアニメーションを適用。

## 挙動
- **初回訪問時:** 動画再生中は音声ボタン・フッター非表示 → 動画終了後、背景画像・Startボタンと共にフェードイン。
- **再訪問時:** 最初から全ての要素を表示（アニメーションなし）。