### PR TITLE
fix: Adobe Fonts読み込み時のFOUT（スタイル崩れ）を防止

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,9 +32,16 @@ export default function RootLayout({
 	const redirectUrl = process.env.NEXT_PUBLIC_CONNECTION_URL || "/connection";
 	return (
 		<html lang="ja" className={`${dotGothic16.variable}`}>
-			<body suppressHydrationWarning>
-				<Script id="adobe-fonts" strategy="afterInteractive">
-					{`
+			<head>
+				<style>{`
+					.wf-loading body {
+						opacity: 0;
+						visibility: hidden;
+					}
+				`}</style>
+				<script
+					dangerouslySetInnerHTML={{
+						__html: `
             (function(d) {
               var config = {
                 kitId: 'jqw4oeg',
@@ -43,8 +50,11 @@ export default function RootLayout({
               },
               h=d.documentElement,t=setTimeout(function(){h.className=h.className.replace(/\\bwf-loading\\b/g,"")+" wf-inactive";},config.scriptTimeout),tk=d.createElement("script"),f=false,s=d.getElementsByTagName("script")[0],a;h.className+=" wf-loading";tk.src='https://use.typekit.net/'+config.kitId+'.js';tk.async=true;tk.onload=tk.onreadystatechange=function(){a=this.readyState;if(f||a&&a!="complete"&&a!="loaded")return;f=true;clearTimeout(t);try{Typekit.load(config)}catch(e){}};s.parentNode.insertBefore(tk,s)
             })(document);
-          `}
-				</Script>
+          `,
+					}}
+				/>
+			</head>
+			<body suppressHydrationWarning>
 				<ClerkProvider
 					signInFallbackRedirectUrl={redirectUrl}
 					signInForceRedirectUrl={redirectUrl}


### PR DESCRIPTION
## 概要
Adobe Fontsの読み込み遅延によるFOUT（Flash of Unstyled Text）を防ぐため、フォント読み込みが完了するまでbody要素を非表示にする対策を行いました。

## 変更点
- `src/app/layout.tsx`:
  - `head` 内にインラインスタイルを追加し、`.wf-loading body { opacity: 0; visibility: hidden; }` を定義。
  - 外部CSSファイルの読み込み待ちによる適用遅れを防ぐため、あえてインラインスタイルを採用。
  - Adobe Fonts読み込みスクリプトを `next/script` から通常の `<script>` タグに変更し、最速で実行されるように調整。

## 挙動
- リロード直後、フォント読み込みが完了するまで（またはタイムアウトするまで）画面は背景色のみの状態となります。
- これにより、標準フォントが一瞬表示されてからWebフォントに切り替わる「ガタつき」を防止します。