### PR TITLE
fix: ゲストユーザーが探索ページにアクセスした際のUIチラつきを修正

### DIFF
--- a/src/features/explore/components/explore-article-analysis/ExploreArticleAnalysis.tsx
+++ b/src/features/explore/components/explore-article-analysis/ExploreArticleAnalysis.tsx
@@ -30,15 +30,19 @@ const ExploreArticleAnalysis: React.FC<ExploreArticleAnalysisProps> = ({
 }) => {
 	const { user } = useUser();
 
-	// ゲストユーザーまたはZenn未連携の場合
-	// ローディング中もゲストユーザーとして判定しない（ちらつき防止）
-	const isGuestUser = !isLoaded || !isZennInfoLoaded ? false : !user || !userZennInfo?.zennUsername;
-
 	const { playClickSound } = useClickSound({
 		soundPath: "/audio/click-sound_decision.mp3",
 		volume: 0.5,
 		delay: 190, // 190ミリ秒 = 0.19秒の遅延
 	});
+
+	// 読み込み中は枠だけ保って中身は表示しない（チラつき・レイアウトシフト防止）
+	if (!isLoaded || !isZennInfoLoaded) {
+		return <div className={styles["explore-article-analysis-container"]}></div>;
+	}
+
+	// ゲストユーザーまたはZenn未連携の場合
+	const isGuestUser = !user || !userZennInfo?.zennUsername;
 
 	return (
 		<div className={styles["explore-article-analysis-container"]}>


### PR DESCRIPTION
## 概要
記事探索ページにおいて、ゲストユーザー（未ログイン状態）でアクセスした際、ロード中に一瞬会員用の「探索結果はここに表示されます」というUIが表示されてしまう問題を修正しました。

## 変更点
- `ExploreArticleAnalysis.tsx`:
  - 認証情報（`isLoaded`, `isZennInfoLoaded`）の読み込みが完了するまでは、空のコンテナ（枠のみ）を表示するように変更。
  - これにより、読み込み完了後に正しいUI（ゲスト用メッセージまたは会員用探索結果）へスムーズに遷移するように修正。

## 挙動
- 修正前：ロード中 -> 一瞬会員用UI -> ゲスト用メッセージ（チラつき発生）
- 修正後：ロード中 -> ゲスト用メッセージ（チラつきなし）