### PR TITLE
fix: フッターのコピーライト更新とスタイル調整

### DIFF
--- a/src/components/layout/footer/Footer.module.css
+++ b/src/components/layout/footer/Footer.module.css
@@ -25,7 +25,7 @@
 .footer-box {
 	display: block grid;
 	place-items: center;
-	width: 170px;
+	width: 135px;
 	height: 30px;
 	background: var(--color-primary-dark-gray);
 	border: var(--border-normal);
@@ -35,8 +35,11 @@
 .footer-text {
 	color: var(--color-primary-yellow);
 	text-shadow:
-		0px 0px 1.25px var(--color-primary-orange),
-		0px 0px 1.25px var(--color-primary-orange),
-		0px 0px 1.25px var(--color-primary-orange);
+		0px 0px 1.5px var(--color-primary-orange),
+		0px 0px 1.5px var(--color-primary-orange),
+		0px 0px 1.5px var(--color-primary-orange),
+		0px 0px 1.5px var(--color-primary-orange),
+		0px 0px 1.5px var(--color-primary-orange),
+		0px 0px 1.5px var(--color-primary-orange);
 	font-family: "ab-don2", sans-serif;
 }

--- a/src/components/layout/footer/Footer.tsx
+++ b/src/components/layout/footer/Footer.tsx
@@ -32,7 +32,7 @@ export const Footer = () => {
 			>
 				<div className={`${styles["footer-box"]}`}>
 					<small className={`${styles["footer-text"]} block text-[10px] font-black`}>
-						© 2025 {siteData.siteMainTitle}
+						© {siteData.siteMainTitle}
 					</small>
 				</div>
 			</div>


### PR DESCRIPTION
## 概要
フッターのコピーライト表記から年号を削除し、それに合わせてスタイル（幅・テキストシャドウ）を微調整しました。

## 変更点
- **`Footer.tsx`**:
  - コピーライト表記を `© 2025 OUTPUT QUEST` から `© OUTPUT QUEST` に変更（年号削除）。
- **`Footer.module.css`**:
  - `.footer-box`: 幅（width）を `170px` から `135px` に縮小してバランスを調整。
  - `.footer-text`: `text-shadow` の設定を変更し、文字の光彩を強化。