### PR TITLE
fix: 記事探索画面のローディング表示ロジックとスタイルを修正

### DIFF
--- a/src/features/explore/components/explore-article-analysis/ExploreArticleAnalysis.module.css
+++ b/src/features/explore/components/explore-article-analysis/ExploreArticleAnalysis.module.css
@@ -3,7 +3,6 @@
 	overflow-y: hidden;
 	display: block grid;
 	grid-area: article-analysis;
-	padding-block-start: 20px;
 
 	@media (width < 1024px) {
 		overflow-y: visible;
@@ -76,13 +75,6 @@
 		opacity: 0;
 		transition: opacity 0.1s;
 	}
-}
-
-.loading-indicator {
-	padding-block-start: 40px;
-	display: block grid;
-	place-items: center;
-	height: 100%;
 }
 
 .explore-analysis-results {

--- a/src/features/explore/components/explore-article-analysis/ExploreArticleAnalysis.tsx
+++ b/src/features/explore/components/explore-article-analysis/ExploreArticleAnalysis.tsx
@@ -4,6 +4,7 @@ import { Fragment } from "react";
 import { useUser } from "@clerk/nextjs";
 import ReactMarkdown from "react-markdown";
 import styles from "./ExploreArticleAnalysis.module.css";
+import LoadingIndicator from "@/components/common/loading-indicator/LoadingIndicator";
 import Link from "next/link";
 import { useClickSound } from "@/components/common/audio/click-sound/ClickSound";
 
@@ -36,9 +37,21 @@ const ExploreArticleAnalysis: React.FC<ExploreArticleAnalysisProps> = ({
 		delay: 190, // 190ミリ秒 = 0.19秒の遅延
 	});
 
-	// 読み込み中は枠だけ保って中身は表示しない（チラつき・レイアウトシフト防止）
+	// 読み込み中はローディングを表示する（遷移時などDynamic Importのloadingが出ない場合への対応）
 	if (!isLoaded || !isZennInfoLoaded) {
-		return <div className={styles["explore-article-analysis-container"]}></div>;
+		return (
+			<div className={styles["explore-article-analysis-container"]}>
+				<div
+					style={{
+						display: "grid",
+						placeItems: "center",
+						height: "100%",
+					}}
+				>
+					<LoadingIndicator text="読み込み中" />
+				</div>
+			</div>
+		);
 	}
 
 	// ゲストユーザーまたはZenn未連携の場合


### PR DESCRIPTION
## 概要
記事探索ページにおいて、別ページからの遷移時にもローディングインジケーターが表示されるようにロジックを修正し、合わせてスタイル調整を行いました。

## 変更点
- **`ExploreArticleAnalysis.tsx`**:
  - 認証情報取得待ちの間、空の `div` ではなく明示的に `LoadingIndicator` を表示するように修正。
  - これにより、Dynamic Import が即座に完了する（遷移時など）場合でも「読み込み中」の状態がユーザーに伝わるようになりました。
- **`ExploreArticleAnalysis.module.css`**:
  - 不要なパディングとクラス定義を削除し、レイアウト崩れを修正。

## 目的
ユーザー体験を一貫させ、どのような遷移経路でも「読み込み中」の状態を正しくフィードバックするため。