### PR TITLE
style: スケルトンコンポーネントの不要なコメントアウトスタイルを削除

### DIFF
--- a/src/features/dashboard/components/dashboard-latest-item-skeleton/DashboardLatestItemSkeleton.module.css
+++ b/src/features/dashboard/components/dashboard-latest-item-skeleton/DashboardLatestItemSkeleton.module.css
@@ -44,12 +44,10 @@
 	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
-	/* border: 7px dashed var(--color-primary-brown-light); */
 	border: 2.7mm ridge #b69973;
 	background-color: var(--color-primary-brown-dark);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
-	/* border-radius: var(--border-radius-small); */
 }
 
 /* matches latest-item-share-link-text */

--- a/src/features/dashboard/components/dashboard-latest-party-member-skeleton/DashboardLatestPartyMemberSkeleton.module.css
+++ b/src/features/dashboard/components/dashboard-latest-party-member-skeleton/DashboardLatestPartyMemberSkeleton.module.css
@@ -44,12 +44,10 @@
 	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
-	/* border: 7px dashed var(--color-primary-brown-light); */
 	border: 2.7mm ridge #b69973;
 	background-color: var(--color-primary-brown-dark);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
-	/* border-radius: var(--border-radius-small); */
 }
 
 /* matches latest-party-member-share-link-text */
@@ -61,7 +59,7 @@
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;
 	margin-top: 10px;
-	place-self: center; /* Center share link skeleton */
+	place-self: center;
 }
 
 @keyframes shimmer {

--- a/src/features/dashboard/components/dashboard-platform-stats-skeleton/DashboardPlatformStatsSkeleton.module.css
+++ b/src/features/dashboard/components/dashboard-platform-stats-skeleton/DashboardPlatformStatsSkeleton.module.css
@@ -42,10 +42,8 @@
 	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
-	/* border: 7px dashed var(--color-primary-brown-light); */
 	border: 3mm ridge #b69973;
 	background-color: var(--color-primary-brown-dark);
-	/* border-radius: var(--border-radius-small); */
 }
 
 /* matches platform-stat-share-link-text */


### PR DESCRIPTION
## 概要
ダッシュボードのスケルトンコンポーネント（アイテム、パーティメンバー、プラットフォーム統計）のCSSから、不要なコメントアウトされたスタイル定義を削除しました。

## 変更点
- **`DashboardLatestItemSkeleton.module.css`**: borderのコメントアウトなどを削除
- **`DashboardLatestPartyMemberSkeleton.module.css`**: borderのコメントアウトなどを削除
- **`DashboardPlatformStatsSkeleton.module.css`**: borderのコメントアウトなどを削除

## 目的
コードのクリーンアップのため。