### PR TITLE
feat: Adventure Log Migration & Logic Updates

### DIFF
--- a/prisma/migrations/20260110002153_add_adventure_log_model/migration.sql
+++ b/prisma/migrations/20260110002153_add_adventure_log_model/migration.sql
@@ -1,0 +1,26 @@
+-- DropIndex
+DROP INDEX "User_clerkId_idx";
+
+-- DropIndex
+DROP INDEX "User_username_idx";
+
+-- CreateTable
+CREATE TABLE "AdventureLog" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "occurredAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AdventureLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AdventureLog_userId_idx" ON "AdventureLog"("userId");
+
+-- CreateIndex
+CREATE INDEX "AdventureLog_occurredAt_idx" ON "AdventureLog"("occurredAt");
+
+-- AddForeignKey
+ALTER TABLE "AdventureLog" ADD CONSTRAINT "AdventureLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,19 +7,31 @@ datasource db {
 }
 
 model User {
-  id               String   @id @default(uuid())
-  clerkId          String   @unique
-  username         String   @unique
-  email            String   @unique
+  id               String         @id @default(uuid())
+  clerkId          String         @unique
+  username         String         @unique
+  email            String         @unique
   displayName      String?
   profileImage     String?
   zennUsername     String?
-  zennArticleCount Int      @default(0)
-  level            Int      @default(1)
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  zennArticleCount Int            @default(0)
+  level            Int            @default(1)
+  createdAt        DateTime       @default(now())
+  updatedAt        DateTime       @updatedAt
+  adventureLogs    AdventureLog[]
 
-  @@index([clerkId])
-  @@index([username])
   @@index([email])
+}
+
+model AdventureLog {
+  id         String   @id @default(uuid())
+  userId     String
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  type       String // "LEVEL_UP", "ITEM_GET", "PARTY_JOIN", "TITLE_GET"
+  content    String
+  occurredAt DateTime
+  createdAt  DateTime @default(now())
+
+  @@index([userId])
+  @@index([occurredAt])
 }

--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+	try {
+		const { userId } = await auth();
+		if (!userId) {
+			return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+		}
+
+		const user = await prisma.user.findUnique({
+			where: { clerkId: userId },
+			select: { id: true },
+		});
+
+		if (!user) {
+			return NextResponse.json({ success: false, error: "User not found" }, { status: 404 });
+		}
+
+		const logs = await prisma.adventureLog.findMany({
+			where: { userId: user.id },
+			orderBy: { occurredAt: "desc" },
+		});
+
+		// Map to string array for compatibility with current UI expectations if needed?
+		// Or return full objects.
+		// Current UI expects string[].
+		// But new UI might want more details (type, etc).
+		// For now, let's return the objects, and the client can format them.
+
+		return NextResponse.json({ success: true, logs });
+	} catch (error) {
+		console.error("Fetch logs error:", error);
+		return NextResponse.json({ success: false, error: "Failed to fetch logs" }, { status: 500 });
+	}
+}

--- a/src/app/api/logs/sync/route.ts
+++ b/src/app/api/logs/sync/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+import { syncAdventureLogs } from "@/features/logs/services/logService";
+
+export async function POST(request: Request) {
+	try {
+		const { userId } = await auth();
+		if (!userId) {
+			return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+		}
+
+		// Find user in DB (we need the DB ID, not Clerk ID for existing check?
+		// Actually logService uses userId. Schema says userId is a String referncing User.id.
+		// Wait, User model: id (uuid), clerkId (String @unique).
+		// logs.userId refers to User.id.
+		// So we must fetch User.id via clerkId.
+
+		const user = await prisma.user.findUnique({
+			where: { clerkId: userId },
+			select: { id: true },
+		});
+
+		if (!user) {
+			return NextResponse.json({ success: false, error: "User not found" }, { status: 404 });
+		}
+
+		const body = await request.json();
+		const { articles } = body;
+
+		if (!Array.isArray(articles)) {
+			return NextResponse.json({ success: false, error: "Invalid articles data" }, { status: 400 });
+		}
+
+		await syncAdventureLogs(user.id, articles);
+
+		return NextResponse.json({ success: true });
+	} catch (error) {
+		console.error("Sync logs error:", error);
+		return NextResponse.json({ success: false, error: "Failed to sync logs" }, { status: 500 });
+	}
+}

--- a/src/features/items/data/itemsData.ts
+++ b/src/features/items/data/itemsData.ts
@@ -35,39 +35,6 @@ export const heroLevelAndItemRelation: { [key: number]: number } = {
 };
 
 // アイテムのタイプ定義
-const customItemType: { [key: number]: string } = {
-	// 全てアイテムとする
-	1: "item",
-	2: "item",
-	3: "item",
-	4: "item",
-	5: "item",
-	6: "item",
-	7: "item",
-	8: "item",
-	9: "item",
-	10: "item",
-	11: "item",
-	12: "item",
-	13: "item",
-	14: "item",
-	15: "item",
-	16: "item",
-	17: "item",
-	18: "item",
-	19: "item",
-	20: "item",
-	21: "item",
-	22: "item",
-	23: "item",
-	24: "item",
-	25: "item",
-	26: "item",
-	27: "item",
-	28: "item",
-	29: "item",
-	30: "item",
-};
 
 // カスタムアイテム名の定義
 export const customItemNames: { [key: number]: string } = {
@@ -232,7 +199,6 @@ const generateItems = (heroLevel: number = 1): Item[] => {
 			description: acquired ? customItemDescriptions[id] : null,
 			image: acquired ? customItemImages[id] : null,
 			acquired,
-			type: customItemType[id] || "item",
 		};
 	});
 };

--- a/src/features/items/types/items.types.ts
+++ b/src/features/items/types/items.types.ts
@@ -4,7 +4,6 @@ export interface Item {
 	description?: string | null;
 	image?: string | null;
 	acquired: boolean;
-	type: string;
 }
 
 export interface ItemsData {

--- a/src/features/logs/components/logs-list/LogsList.tsx
+++ b/src/features/logs/components/logs-list/LogsList.tsx
@@ -11,13 +11,38 @@ const LogsList = () => {
 	const [loading, setLoading] = useState(true);
 
 	useEffect(() => {
-		// ローカルストレージからログを取得
-		const savedLogs = localStorage.getItem(LOGS_STORAGE_KEY);
-		if (savedLogs) {
-			// 取得した文字列を配列に変換
-			setLogs(JSON.parse(savedLogs));
-		}
-		setLoading(false);
+		// APIからログを取得
+		const fetchLogs = async () => {
+			try {
+				const res = await fetch("/api/logs");
+				const data = await res.json();
+				if (data.success && Array.isArray(data.logs)) {
+					const formattedLogs = data.logs.map((log: any) => {
+						const date = new Date(log.occurredAt);
+						const formattedDate = `${date.getFullYear()}/${(date.getMonth() + 1)
+							.toString()
+							.padStart(2, "0")}/${date.getDate().toString().padStart(2, "0")} ${date
+							.getHours()
+							.toString()
+							.padStart(2, "0")}:${date.getMinutes().toString().padStart(2, "0")}:${date
+							.getSeconds()
+							.toString()
+							.padStart(2, "0")}`;
+						return `${formattedDate} ${log.content}`;
+					});
+					setLogs(formattedLogs);
+				} else {
+					setLogs([]);
+				}
+			} catch (err) {
+				console.error("Failed to fetch logs:", err);
+				setLogs([]);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		fetchLogs();
 	}, []);
 
 	return (

--- a/src/features/logs/services/logService.ts
+++ b/src/features/logs/services/logService.ts
@@ -1,0 +1,132 @@
+import { prisma } from "@/lib/prisma";
+import { heroLevelAndItemRelation, customItemNames } from "@/features/items/data/itemsData";
+import {
+	heroLevelAndMemberRelation,
+	customMemberNames,
+} from "@/features/party/data/partyMemberData";
+import { titleNameData } from "@/shared/data/titleNameDate";
+
+interface Article {
+	id: number;
+	title: string;
+	publishedAt?: string | null;
+	date?: string | Date;
+}
+
+/**
+ * Syncs the adventure logs for a user.
+ * It deletes all existing logs and regenerates them based on the provided articles.
+ */
+export const syncAdventureLogs = async (userId: string, articles: Article[]) => {
+	if (!articles || articles.length === 0) return;
+
+	// Sort articles by date (oldest to newest)
+	const sortedArticles = [...articles].sort((a, b) => {
+		const dateA = new Date(getDateStr(a)).getTime();
+		const dateB = new Date(getDateStr(b)).getTime();
+		return dateA - dateB;
+	});
+
+	const logsToCreate: {
+		userId: string;
+		type: string;
+		content: string;
+		occurredAt: Date;
+	}[] = [];
+
+	let currentLevel = 0;
+
+	console.log("Syncing adventure logs with offsets for userId:", userId);
+
+	// Process each article
+	for (const article of sortedArticles) {
+		currentLevel++;
+		const baseDate = new Date(getDateStr(article));
+
+		// Define offsets to ensure logical chronological order:
+		// 1. Level Up (Base Time) -> Happens FIRST
+		// 2. Unlocks (Item/Party/Title) -> Happen AFTER Level Up
+
+		// In DESC sort (Newest First), the visual order will be:
+		// Top: Title (+30ms)
+		// ...: Party (+20ms)
+		// ...: Item (+10ms)
+		// Bottom: Level Up (+0ms)
+
+		// 1. Level Up Log (Base Time + 0ms)
+		logsToCreate.push({
+			userId,
+			type: "LEVEL_UP",
+			content: `経験値を1獲得！勇者は「Lv${currentLevel}」にあがった！`,
+			occurredAt: baseDate, // +0ms (Earliest)
+		});
+
+		// 2. Item Unlock Logs (Base Time + 10ms)
+		for (const [itemIdStr, reqLevel] of Object.entries(heroLevelAndItemRelation)) {
+			if (reqLevel === currentLevel) {
+				const name = customItemNames[Number(itemIdStr)];
+				if (name) {
+					logsToCreate.push({
+						userId,
+						type: "ITEM_GET",
+						content: `勇者は「${name}」を手に入れた！`,
+						occurredAt: new Date(baseDate.getTime() + 10), // +10ms
+					});
+				}
+			}
+		}
+
+		// 3. Party Member Unlock Logs (Base Time + 20ms)
+		for (const [memberIdStr, reqLevel] of Object.entries(heroLevelAndMemberRelation)) {
+			if (reqLevel === currentLevel) {
+				const name = customMemberNames[Number(memberIdStr)];
+				if (name) {
+					logsToCreate.push({
+						userId,
+						type: "PARTY_JOIN",
+						content: `「${name}」が仲間に加わった！`,
+						occurredAt: new Date(baseDate.getTime() + 20), // +20ms
+					});
+				}
+			}
+		}
+
+		// 4. Title Unlock Logs (Base Time + 30ms)
+		if (currentLevel === 1) {
+			const title = titleNameData.find((t) => t.id === 1);
+			if (title) {
+				logsToCreate.push({
+					userId,
+					type: "TITLE_GET",
+					content: `称号「${title.name}」を獲得した！`,
+					occurredAt: new Date(baseDate.getTime() + 30), // +30ms
+				});
+			}
+		}
+		if (currentLevel % 10 === 0) {
+			const titleId = currentLevel / 10 + 1;
+			const title = titleNameData.find((t) => t.id === titleId);
+			if (title) {
+				logsToCreate.push({
+					userId,
+					type: "TITLE_GET",
+					content: `称号「${title.name}」を獲得した！`,
+					occurredAt: new Date(baseDate.getTime() + 30), // +30ms
+				});
+			}
+		}
+	}
+
+	// Transaction: Delete all old logs and insert new ones
+	await prisma.$transaction([
+		prisma.adventureLog.deleteMany({ where: { userId } }),
+		prisma.adventureLog.createMany({ data: logsToCreate }),
+	]);
+};
+
+const getDateStr = (article: Article): string => {
+	return (
+		article.publishedAt ??
+		(typeof article.date === "string" ? article.date : new Date().toISOString())
+	);
+};

--- a/src/features/strength/components/strength-log-info/StrengthLogInfo.tsx
+++ b/src/features/strength/components/strength-log-info/StrengthLogInfo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import styles from "./StrengthLogInfo.module.css";
 import { fetchZennArticles } from "@/features/posts/services";
 import Link from "next/link";
@@ -15,6 +15,7 @@ const StrengthLogInfo = () => {
 	const [logs, setLogs] = useState<string[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
+	const hasSynced = useRef(false);
 
 	const router = useRouter();
 	const { playClickSound } = useClickSound({
@@ -31,9 +32,11 @@ const StrengthLogInfo = () => {
 	useEffect(() => {
 		// コンポーネントマウント時に実行される
 		const initializeLogs = async () => {
+			if (hasSynced.current) return;
+			hasSynced.current = true;
+
 			try {
-				// 全記事分のログを生成
-				await generateLogs();
+				await syncAndFetchLogs();
 			} catch (err) {
 				console.error("ログの初期化エラー:", err);
 				setError("ログデータの初期化中にエラーが発生しました。");
@@ -45,57 +48,54 @@ const StrengthLogInfo = () => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []); // 依存配列は空のまま（初回マウント時のみ実行）
 
-	// Zenn記事からログを生成する関数
-	const generateLogs = async () => {
+	// ログを同期・取得する関数
+	const syncAndFetchLogs = async () => {
 		try {
 			setLoading(true);
 
-			// 連携済みユーザー情報を取得
+			// 1. Zennユーザー名取得
 			const userRes = await fetch("/api/user");
 			const userData = await userRes.json();
-
-			let username = null;
-
-			if (!userData.success || !userData.user.zennUsername) {
-				// ゲストユーザーまたは連携未設定の場合は@aoyamadevのデータを使用
-				username = "aoyamadev";
-			} else {
+			let username = "aoyamadev";
+			if (userData.success && userData.user.zennUsername) {
 				username = userData.user.zennUsername;
 			}
-			// Zenn記事を取得
+
+			// 2. Zenn記事取得（すべての記事）
 			const articles = await fetchZennArticles(username, {
 				fetchAll: true,
 			});
 
-			if (articles.length === 0) {
-				const defaultLogs = generateDefaultLogs();
-				saveLogs(defaultLogs);
-				setLogs(defaultLogs);
-				return;
-			}
-
-			// 全記事をループしてログ配列を生成（最新順）
-			const totalCount = articles.length;
-			const newLogs = articles.map((article, index) => {
-				const dateStr =
-					article.publishedAt ??
-					(typeof article.date === "string" ? article.date : article.date?.toISOString());
-				const date = dateStr ? new Date(dateStr) : new Date();
-				const formattedDate = formatDate(date);
-				const level = totalCount - index;
-				return `${formattedDate} 経験値を1獲得！勇者は「Lv${level}」にあがった！`;
+			// 3. ログ同期APIを呼び出し（記事データを送信してDBを更新）
+			await fetch("/api/logs/sync", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ articles }),
 			});
 
-			// 保存して状態にセット
-			saveLogs(newLogs);
-			setLogs(newLogs);
-		} catch (err) {
-			console.error("Zenn記事の取得エラー:", err);
+			// 4. DBから最新のログを取得
+			const logsRes = await fetch("/api/logs");
+			const logsData = await logsRes.json();
 
-			// エラー時はデフォルトログを表示
-			const defaultLogs = generateDefaultLogs();
-			saveLogs(defaultLogs);
-			setLogs(defaultLogs);
+			if (logsData.success && Array.isArray(logsData.logs)) {
+				// ログデータを文字列配列に変換してセット（既存UIとの互換性のため）
+				// adventureLog: { content: string, occurredAt, ... }
+				// 日付を含めるかどうかは呼び出し元次第だが、サーバー側で生成した content だけ使うか
+				// 元の実装では "yyyy/mm/dd hh:mm content" 形式だった
+				const formattedLogs = logsData.logs.map((log: any) => {
+					const date = new Date(log.occurredAt);
+					const formattedDate = formatDate(date);
+					return `${formattedDate} ${log.content}`;
+				});
+				setLogs(formattedLogs);
+			} else {
+				// ログがない場合
+				setLogs(generateDefaultLogs());
+			}
+		} catch (err) {
+			console.error("ログ同期エラー:", err);
+			// エラー時はデフォルトログ
+			setLogs(generateDefaultLogs());
 		} finally {
 			setLoading(false);
 		}
@@ -119,19 +119,7 @@ const StrengthLogInfo = () => {
 		return ["冒険ログはまだありません", "---"];
 	};
 
-	// ログを保存する関数
-	const saveLogs = (logs: string[]) => {
-		if (typeof window === "undefined") return;
-
-		try {
-			// 保存前に重複を取り除く
-			const uniqueLogs = Array.from(new Set(logs));
-			localStorage.setItem(ADVENTURE_LOGS_KEY, JSON.stringify(uniqueLogs));
-		} catch (e) {
-			console.error("ログの保存エラー:", e);
-		}
-	};
-
+	// エラー表示
 	if (error) {
 		return (
 			<div className={styles["strength-log-info"]}>


### PR DESCRIPTION
## 概要
冒険の記録（Adventure Log）機能をLocalStorageからSupabase/Prisma v7へ移行し、ログ生成ロジックとアイテムデータの型定義を刷新しました。

## 主な変更点
- **データ移行**: LocalStorageからSupabase (Prisma) への完全移行。
- **時系列ソート修正**: レベルアップとアンロック（アイテム・仲間）のログ順序が逆転する問題を、ミリ秒単位のオフセット調整で修正。
- **二重投稿防止**: React Strict Modeによる重複ログ生成を`useRef`で防止。
- **リファクタリング**: `itemsData.ts` の未使用型定義を削除。

## 関連Issue/Task
- [Task Log](https://github.com/camoneart/outputquest/blob/main/_docs/templates/2026-01-10_adventure-log-migration.md)

## 動作確認
- [x] ログが降順（新しい順）で正しく表示されること
- [x] レベルアップ → アンロックの順で時系列が正しいこと
- [x] 重複ログが発生しないこと