### PR TITLE
fix: resolve hydration mismatch and Vercel build config

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
 }>) {
 	const redirectUrl = process.env.NEXT_PUBLIC_CONNECTION_URL || "/connection";
 	return (
-		<html lang="ja" className={`${dotGothic16.variable}`}>
+		<html lang="ja" className={`${dotGothic16.variable}`} suppressHydrationWarning>
 			<head>
 				<style>{`
 					.wf-loading body {


### PR DESCRIPTION
## 変更内容
- `src/app/layout.tsx`: Adobe Fontsによるハイドレーションエラー (#418) を解消するため、`html` タグに `suppressHydrationWarning` を追加。
- ビルド設定の確認: `next.config.ts` の `cacheComponents: true` によりデフォルトで動的レンダリングになることを確認し、不要な `force-dynamic` 設定を削除（リバート）。

## 動作確認
- ローカルビルドおよびVercelデプロイでビルドが通ること。
- ブラウザコンソールからHydration Errorが消えていること。