### PR TITLE
fix(prisma): サーバーレス環境でのDB接続エラーを修正

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -5,19 +5,33 @@ import { Pool } from "pg";
 
 const globalForPrisma = globalThis as unknown as {
 	prisma: PrismaClient | undefined;
+	pool: Pool | undefined;
 };
 
 const prismaClientSingleton = () => {
-	const pool = new Pool({ connectionString: process.env.DATABASE_URL });
-	const adapter = new PrismaPg(pool);
+	// Vercelのサーバーレス環境でのコネクション管理を改善
+	// グローバルなPoolを再利用することで、Connection closedエラーを防ぐ
+	if (!globalForPrisma.pool) {
+		globalForPrisma.pool = new Pool({
+			connectionString: process.env.DATABASE_URL,
+			// サーバーレス環境向けの設定
+			max: 10, // 最大接続数
+			idleTimeoutMillis: 30000, // アイドル接続のタイムアウト
+			connectionTimeoutMillis: 10000, // 接続タイムアウト
+		});
+	}
+
+	const adapter = new PrismaPg(globalForPrisma.pool);
 	return new PrismaClient({
 		adapter,
 		log: ["warn", "error"],
 	});
 };
 
-export const prisma = globalForPrisma.prisma || prismaClientSingleton();
+export const prisma = globalForPrisma.prisma ?? prismaClientSingleton();
 
-if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+// 開発環境・本番環境ともにグローバル変数を使用
+// サーバーレス環境でのコネクション再利用を可能にする
+globalForPrisma.prisma = prisma;
 
 export default prisma;


### PR DESCRIPTION
## 概要
Vercel本番環境でダッシュボードページにアクセスすると発生していた「Error: Connection closed」エラーを修正しました。

## 問題
- Vercel Runtime Logsに以下のエラーが記録されていた：
  ```
  Failed to fetch dashboard hero data: Error: Connection closed.
  ```
- Digest: 2369933331

## 原因
1. **本番環境でグローバル変数が使用されていなかった**
   - 以前のコードでは `if (process.env.NODE_ENV !== "production")` の条件で開発環境のみグローバル変数に保存
   - 本番環境では毎回新しいPrismaクライアントとコネクションプールが作成されていた

2. **コネクションプールの設定が不十分**
   - サーバーレス環境向けの設定（max, idleTimeoutMillis, connectionTimeoutMillis）がなかった

## 解決策
1. **グローバルなPoolを追加**
   - 接続プールをグローバル変数で管理し、再利用
   
2. **サーバーレス環境向けの設定を追加**
   ```typescript
   max: 10,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 10000,
   ```

3. **本番環境でもグローバル変数を使用**
   - `if (process.env.NODE_ENV !== "production")` の条件を削除

## 変更ファイル
- `src/lib/prisma.ts`

## テスト計画
- [ ] ローカルビルド確認 ✅
- [ ] Vercelプレビュー環境で動作確認
- [ ] 本番環境（outputquest.com/dashboard）で動作確認

## 注意
`DATABASE_URL`に`?pgbouncer=true`が含まれていることを確認してください。Supabaseのサーバーレス環境では、PgBouncerを使用することで接続管理が改善されます。