### PR TITLE
fix(auth): cacheComponents有効時のプリレンダリングエラーを修正

### DIFF
--- a/src/features/items/components/item-card-list/ItemCardList.tsx
+++ b/src/features/items/components/item-card-list/ItemCardList.tsx
@@ -1,3 +1,4 @@
+import { connection } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { prisma } from "@/lib/prisma";
 import { fetchZennArticles } from "@/features/posts/services";
@@ -6,6 +7,9 @@ import * as Items from "@/features/items/components";
 import styles from "./ItemCardList.module.css";
 
 const ItemCardList = async () => {
+	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
+	await connection();
+
 	try {
 		// 認証情報を取得
 		const { userId } = await auth();

--- a/src/features/party/components/party-member-card-list/PartyMemberCardList.tsx
+++ b/src/features/party/components/party-member-card-list/PartyMemberCardList.tsx
@@ -1,3 +1,4 @@
+import { connection } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { prisma } from "@/lib/prisma";
 import { fetchZennArticles } from "@/features/posts/services";
@@ -6,6 +7,9 @@ import * as Party from "@/features/party/components";
 import styles from "./PartyMemberCardList.module.css";
 
 const PartyMemberCardList = async () => {
+	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
+	await connection();
+
 	try {
 		// 認証情報を取得
 		const { userId } = await auth();

--- a/src/features/posts/components/posts-list-with-data/PostsListWithData.tsx
+++ b/src/features/posts/components/posts-list-with-data/PostsListWithData.tsx
@@ -1,3 +1,4 @@
+import { connection } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { prisma } from "@/lib/prisma";
 import { getZennArticles } from "@/features/zenn/_lib/fetcher";
@@ -6,6 +7,9 @@ import * as Posts from "@/features/posts/components";
 import styles from "./PostsListWithData.module.css";
 
 const PostsListWithData = async () => {
+	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
+	await connection();
+
 	try {
 		// 認証情報を取得
 		const { userId } = await auth();

--- a/src/features/strength/components/strength-hero-info/StrengthHeroInfo.tsx
+++ b/src/features/strength/components/strength-hero-info/StrengthHeroInfo.tsx
@@ -1,3 +1,4 @@
+import { connection } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { prisma } from "@/lib/prisma";
 import { getZennArticles } from "@/features/zenn/_lib/fetcher";
@@ -18,6 +19,9 @@ import styles from "./StrengthHeroInfo.module.css";
  * - レベル計算（記事数 = レベル）
  */
 const StrengthHeroInfo = async () => {
+	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
+	await connection();
+
 	try {
 		// 認証情報を取得
 		const { userId } = await auth();

--- a/src/features/user/_lib/fetcher.ts
+++ b/src/features/user/_lib/fetcher.ts
@@ -1,6 +1,7 @@
 import "server-only"; // Part 1推奨: サーバー専用コードの保護
 import { cache } from "react";
 import { cacheTag } from "next/cache";
+import { connection } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@clerk/nextjs/server";
 import { CacheTags } from "@/lib/cache-tags";
@@ -68,6 +69,9 @@ async function getCachedUserData(clerkId: string): Promise<User> {
  * @returns ユーザー情報（認証されていない場合はnull）
  */
 export const getUser = cache(async (): Promise<User> => {
+	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
+	await connection();
+
 	try {
 		// 認証チェック（キャッシュしない、動的API）
 		const { userId } = await auth();


### PR DESCRIPTION
## Summary
- Next.js 16のcacheComponents有効時、プリレンダリング中に`auth()`を呼ぶと`headers()`がrejectされるエラーを修正
- 各Server Componentで`auth()`の前に`connection()`を呼び出すことでDynamic Renderingを強制
- `export const dynamic = "force-dynamic"`はcacheComponentsと互換性がないため、代替アプローチとして`connection()`を使用

## 修正ファイル
- `src/features/items/components/item-card-list/ItemCardList.tsx`
- `src/features/party/components/party-member-card-list/PartyMemberCardList.tsx`
- `src/features/posts/components/posts-list-with-data/PostsListWithData.tsx`
- `src/features/strength/components/strength-hero-info/StrengthHeroInfo.tsx`
- `src/features/user/_lib/fetcher.ts`

## Test plan
- [ ] `pnpm build` が成功することを確認 ✅
- [ ] 本番環境で `/dashboard` が正常に表示されることを確認
- [ ] `/items`, `/party`, `/posts`, `/strength` ページが正常に表示されることを確認