### PR TITLE
fix(css): ExploreArticleAnalysisとStrengthHeroInfoSkeletonのスタイル調整

### DIFF
--- a/src/features/explore/components/explore-article-analysis/ExploreArticleAnalysis.module.css
+++ b/src/features/explore/components/explore-article-analysis/ExploreArticleAnalysis.module.css
@@ -3,6 +3,7 @@
 	overflow-y: hidden;
 	display: block grid;
 	grid-area: article-analysis;
+	padding-block-start: 30px;
 
 	@media (width < 1024px) {
 		overflow-y: visible;
@@ -108,7 +109,7 @@
 .explore-results-content {
 	overflow: hidden;
 	background-color: var(--color-primary-brown-dark);
-	border: 5mm ridge #b69973;
+	border: 4mm ridge #b69973;
 	padding-block: 3px;
 	padding-inline: 3px;
 }

--- a/src/features/strength/components/strength-hero-info-skeleton/StrengthHeroInfoSkeleton.module.css
+++ b/src/features/strength/components/strength-hero-info-skeleton/StrengthHeroInfoSkeleton.module.css
@@ -1,11 +1,11 @@
 /* Container - matches strength-hero-info */
 .skeleton-container {
 	height: 100%;
-	padding-inline: 5px;
-	padding-block: 5px;
+	border: 3mm ridge #b69973;
 	background-color: var(--color-primary-brown-dark);
-	border: 3px solid var(--color-primary-brown-light);
 	border-radius: var(--border-radius-small);
+	padding-inline: 2.5px;
+	padding-block: 2.5px;
 }
 
 /* Content - matches strength-hero-info-content */
@@ -15,8 +15,8 @@
 	grid-template-columns: auto;
 	grid-template-rows: auto 1fr auto;
 	gap: 10px;
+	background-color: #ae926e;
 	border: 2px solid var(--color-primary-brown-light);
-	background-color: var(--color-primary-brown);
 	padding-inline: 10px;
 	padding-block: 10px;
 	min-height: 220px; /* CLS prevention */


### PR DESCRIPTION
## Summary
- ExploreArticleAnalysis: padding-block-start追加、borderを5mm→4mmに調整
- StrengthHeroInfoSkeleton: borderスタイルとpadding、背景色を本体コンポーネントに合わせて調整

## Test plan
- [ ] `/explore` ページのレイアウト確認
- [ ] `/strength` ページのスケルトン表示確認