### PR TITLE
fix(css): LogsListとStrengthLogInfoのスタイル調整

### DIFF
--- a/src/features/logs/components/logs-list/LogsList.tsx
+++ b/src/features/logs/components/logs-list/LogsList.tsx
@@ -55,7 +55,7 @@ const LogsList = () => {
 				</li>
 			) : logs.length === 0 ? (
 				<li className={styles["logs-page-list-item"]}>
-					<p className={styles["logs-page-list-item-text"]}>まだ冒険ログがありません。</p>
+					<p className={styles["logs-page-list-item-text"]}>表示できる冒険ログがありません</p>
 				</li>
 			) : (
 				logs.map((log, index) => (

--- a/src/features/strength/components/strength-log-info/StrengthLogInfo.module.css
+++ b/src/features/strength/components/strength-log-info/StrengthLogInfo.module.css
@@ -8,7 +8,7 @@
 
 .strength-log-info-content {
 	height: 100%;
-	display: grid;
+	display: block grid;
 	grid-template-columns: auto;
 	gap: 20px;
 	background-color: #ae926e;
@@ -16,7 +16,7 @@
 }
 
 .strength-log-box {
-	display: grid;
+	display: block grid;
 	grid-template-columns: auto;
 	grid-template-rows: auto 1fr auto;
 	grid-template-areas:
@@ -41,7 +41,7 @@
 }
 
 .strength-log-list-content {
-	display: grid;
+	display: block grid;
 	grid-area: content;
 }
 
@@ -56,10 +56,11 @@
 
 .strength-log-list {
 	width: 100%;
-	max-height: 208px;
-	min-height: 208px;
-	display: grid;
-
+	height: 100%;
+	/* max-height: 208px;
+	min-height: 208px; */
+	display: block grid;
+	align-content: center;
 	justify-content: center;
 	gap: 10px;
 	padding-inline: 10px;
@@ -76,7 +77,7 @@
 .strength-log-loading-text {
 	font-size: 0.875rem;
 	font-weight: var(--font-weight-normal);
-	display: grid;
+	display: block grid;
 	place-items: center;
 	padding-block-start: 15px;
 }
@@ -87,7 +88,7 @@
 }
 
 .strength-log-link-box {
-	display: grid;
+	display: block grid;
 	place-items: center;
 	grid-area: footer;
 }

--- a/src/features/strength/components/strength-log-info/StrengthLogInfo.tsx
+++ b/src/features/strength/components/strength-log-info/StrengthLogInfo.tsx
@@ -116,7 +116,7 @@ const StrengthLogInfo = () => {
 
 	// デフォルトのログを生成
 	const generateDefaultLogs = (): string[] => {
-		return ["冒険ログはまだありません", "---"];
+		return ["表示できる冒険ログがありません"];
 	};
 
 	// エラー表示
@@ -149,7 +149,7 @@ const StrengthLogInfo = () => {
 									</li>
 								) : (
 									// 最大15件のログのみ表示
-									logs.slice(0, 15).map((log, index) => (
+									logs.slice(0, 7).map((log, index) => (
 										<li key={index} className={styles["strength-log-item"]}>
 											<p className={styles["strength-log-text"]}>{log}</p>
 										</li>


### PR DESCRIPTION
## Summary
- LogsList: スタイル調整
- StrengthLogInfo: スタイル調整

## Test plan
- [x] `/strength` ページの冒険ログ表示確認
- [x] `/logs` ページの表示確認