### PR TITLE
fix(logs): 冒険ログをサーバーサイド取得に変更

### DIFF
--- a/src/app/(main)/logs/LogsPage.module.css
+++ b/src/app/(main)/logs/LogsPage.module.css
@@ -69,3 +69,17 @@
 		margin-inline: auto;
 	}
 }
+
+/* スケルトン用スタイル */
+.logs-page-list-skeleton {
+	grid-area: list;
+	display: block grid;
+	place-items: center;
+	height: 100%;
+	padding-block: 15px;
+	padding-inline: 20px;
+}
+
+.logs-page-list-item-skeleton {
+	color: var(--color-primary-white);
+}

--- a/src/app/(main)/logs/page.tsx
+++ b/src/app/(main)/logs/page.tsx
@@ -1,9 +1,20 @@
 import { Metadata } from "next";
+import { Suspense } from "react";
 import { getPageMetadata } from "@/config/metadata";
 import styles from "./LogsPage.module.css";
 import * as Logs from "@/features/logs/components";
+import LoadingIndicator from "@/components/common/loading-indicator/LoadingIndicator";
 
 export const metadata: Metadata = getPageMetadata("logs");
+
+// ローディング用フォールバック
+const LogsListSkeleton = () => (
+	<ul className={styles["logs-page-list-skeleton"]}>
+		<li className={styles["logs-page-list-item-skeleton"]}>
+			<LoadingIndicator text="読み込み中" />
+		</li>
+	</ul>
+);
 
 const LogsPage = () => {
 	return (
@@ -15,7 +26,9 @@ const LogsPage = () => {
 
 				<hr className={styles["logs-page-line-first"]} />
 
-				<Logs.LogsList />
+				<Suspense fallback={<LogsListSkeleton />}>
+					<Logs.LogsListWrapper />
+				</Suspense>
 
 				<hr className={styles["logs-page-line-second"]} />
 

--- a/src/app/(main)/strength/StrengthPage.module.css
+++ b/src/app/(main)/strength/StrengthPage.module.css
@@ -37,6 +37,11 @@
 	height: 100%;
 }
 
+.strength-log-wrapper {
+	width: 100%;
+	height: 100%;
+}
+
 .strength-content {
 	width: 100%;
 	height: 100%;

--- a/src/app/(main)/strength/page.tsx
+++ b/src/app/(main)/strength/page.tsx
@@ -19,7 +19,11 @@ const StrengthPage = () => {
 						</Suspense>
 					</div>
 					{/* （右上）冒険ログ */}
-					<Strength.StrengthLogInfo />
+					<div className={styles["strength-log-wrapper"]}>
+						<Suspense fallback={<Strength.StrengthLogInfoSkeleton />}>
+							<Strength.StrengthLogInfoWrapper />
+						</Suspense>
+					</div>
 					{/* （下）称号 */}
 					<Strength.StrengthTitleInfo />
 				</div>

--- a/src/features/logs/components/index.ts
+++ b/src/features/logs/components/index.ts
@@ -1,5 +1,6 @@
 import LogsPageFooter from "./logs-page-footer/LogsPageFooter";
 import LogsList from "./logs-list/LogsList";
+import LogsListWrapper from "./logs-list/LogsListWrapper";
 import LogsPageHeader from "./logs-page-header/LogsPageHeader";
 
-export { LogsPageFooter, LogsList, LogsPageHeader };
+export { LogsPageFooter, LogsList, LogsListWrapper, LogsPageHeader };

--- a/src/features/logs/components/logs-list/LogsList.tsx
+++ b/src/features/logs/components/logs-list/LogsList.tsx
@@ -1,64 +1,25 @@
-"use client";
-
-import { useEffect, useState } from "react";
 import styles from "./LogsList.module.css";
-import LoadingIndicator from "@/components/common/loading-indicator/LoadingIndicator";
+import type { FormattedLog } from "@/features/logs/services/logService";
 
-const LOGS_STORAGE_KEY = "adventure_logs";
+interface LogsListProps {
+	logs: FormattedLog[];
+}
 
-const LogsList = () => {
-	const [logs, setLogs] = useState<string[]>([]);
-	const [loading, setLoading] = useState(true);
-
-	useEffect(() => {
-		// APIからログを取得
-		const fetchLogs = async () => {
-			try {
-				const res = await fetch("/api/logs");
-				const data = await res.json();
-				if (data.success && Array.isArray(data.logs)) {
-					const formattedLogs = data.logs.map((log: any) => {
-						const date = new Date(log.occurredAt);
-						const formattedDate = `${date.getFullYear()}/${(date.getMonth() + 1)
-							.toString()
-							.padStart(2, "0")}/${date.getDate().toString().padStart(2, "0")} ${date
-							.getHours()
-							.toString()
-							.padStart(2, "0")}:${date.getMinutes().toString().padStart(2, "0")}:${date
-							.getSeconds()
-							.toString()
-							.padStart(2, "0")}`;
-						return `${formattedDate} ${log.content}`;
-					});
-					setLogs(formattedLogs);
-				} else {
-					setLogs([]);
-				}
-			} catch (err) {
-				console.error("Failed to fetch logs:", err);
-				setLogs([]);
-			} finally {
-				setLoading(false);
-			}
-		};
-
-		fetchLogs();
-	}, []);
+const LogsList = ({ logs }: LogsListProps) => {
+	// ログがない場合のデフォルトメッセージ
+	const displayLogs =
+		logs.length > 0
+			? logs.map((log) => `${log.formattedDate} ${log.content}`)
+			: [];
 
 	return (
 		<ul className={styles["logs-page-list"]}>
-			{loading ? (
-				<li className={styles["logs-page-list-item"]}>
-					<div className={styles["logs-page-list-item-loading-text"]}>
-						<LoadingIndicator text="読み込み中" className={styles["loading-indicator"]} />
-					</div>
-				</li>
-			) : logs.length === 0 ? (
+			{displayLogs.length === 0 ? (
 				<li className={styles["logs-page-list-item"]}>
 					<p className={styles["logs-page-list-item-text"]}>表示できる冒険ログはまだありません</p>
 				</li>
 			) : (
-				logs.map((log, index) => (
+				displayLogs.map((log, index) => (
 					<li key={index} className={styles["logs-page-list-item"]}>
 						<p className={styles["logs-page-list-item-text"]}>{log}</p>
 					</li>

--- a/src/features/logs/components/logs-list/LogsListWrapper.tsx
+++ b/src/features/logs/components/logs-list/LogsListWrapper.tsx
@@ -1,0 +1,15 @@
+import { auth } from "@clerk/nextjs/server";
+import { getAdventureLogs } from "@/features/logs/services/logService";
+import LogsList from "./LogsList";
+
+/**
+ * サーバーコンポーネント：ログを取得してLogsListに渡す
+ */
+const LogsListWrapper = async () => {
+	const { userId } = await auth();
+	const logs = userId ? await getAdventureLogs(userId) : [];
+
+	return <LogsList logs={logs} />;
+};
+
+export default LogsListWrapper;

--- a/src/features/logs/services/logService.ts
+++ b/src/features/logs/services/logService.ts
@@ -130,3 +130,61 @@ const getDateStr = (article: Article): string => {
 		(typeof article.date === "string" ? article.date : new Date().toISOString())
 	);
 };
+
+/**
+ * ログをフォーマットするための型
+ */
+export interface FormattedLog {
+	id: string;
+	type: string;
+	content: string;
+	occurredAt: Date;
+	formattedDate: string;
+}
+
+/**
+ * 日付をフォーマットする関数
+ */
+const formatDate = (date: Date): string => {
+	return `${date.getFullYear()}/${(date.getMonth() + 1)
+		.toString()
+		.padStart(2, "0")}/${date.getDate().toString().padStart(2, "0")} ${date
+		.getHours()
+		.toString()
+		.padStart(2, "0")}:${date.getMinutes().toString().padStart(2, "0")}:${date
+		.getSeconds()
+		.toString()
+		.padStart(2, "0")}`;
+};
+
+/**
+ * サーバーサイドでAdventureLogを取得する関数
+ * Zenn連携しているユーザーのみログを返す
+ */
+export const getAdventureLogs = async (clerkId: string): Promise<FormattedLog[]> => {
+	// ユーザーを取得
+	const user = await prisma.user.findUnique({
+		where: { clerkId },
+		select: { id: true, zennUsername: true },
+	});
+
+	// ユーザーが存在しない、またはZenn未連携の場合は空配列
+	if (!user || !user.zennUsername) {
+		return [];
+	}
+
+	// AdventureLogを取得
+	const logs = await prisma.adventureLog.findMany({
+		where: { userId: user.id },
+		orderBy: { occurredAt: "desc" },
+	});
+
+	// フォーマットして返す
+	return logs.map((log) => ({
+		id: log.id,
+		type: log.type,
+		content: log.content,
+		occurredAt: log.occurredAt,
+		formattedDate: formatDate(log.occurredAt),
+	}));
+};

--- a/src/features/strength/components/index.ts
+++ b/src/features/strength/components/index.ts
@@ -2,6 +2,8 @@ import StrengthHeroInfo from "./strength-hero-info/StrengthHeroInfo";
 import StrengthHeroInfoClient from "./strength-hero-info-client/StrengthHeroInfoClient";
 import StrengthHeroInfoSkeleton from "./strength-hero-info-skeleton/StrengthHeroInfoSkeleton";
 import StrengthLogInfo from "./strength-log-info/StrengthLogInfo";
+import StrengthLogInfoSkeleton from "./strength-log-info-skeleton/StrengthLogInfoSkeleton";
+import StrengthLogInfoWrapper from "./strength-log-info/StrengthLogInfoWrapper";
 import StrengthTitleInfo from "./strength-title-info/StrengthTitleInfo";
 
 export {
@@ -9,5 +11,7 @@ export {
 	StrengthHeroInfoClient,
 	StrengthHeroInfoSkeleton,
 	StrengthLogInfo,
+	StrengthLogInfoSkeleton,
+	StrengthLogInfoWrapper,
 	StrengthTitleInfo,
 };

--- a/src/features/strength/components/strength-log-info-skeleton/StrengthLogInfoSkeleton.module.css
+++ b/src/features/strength/components/strength-log-info-skeleton/StrengthLogInfoSkeleton.module.css
@@ -1,0 +1,14 @@
+.skeleton-link {
+	font-size: 0.875rem;
+	font-weight: var(--font-weight-bold);
+	color: var(--color-primary-white);
+	opacity: 0.5;
+	text-shadow: 1px 1px 0px var(--color-primary-black);
+}
+
+/* 実際のコンテンツと同じ高さを確保 */
+.skeleton-list {
+	min-height: 208px;
+	display: grid;
+	place-items: center;
+}

--- a/src/features/strength/components/strength-log-info-skeleton/StrengthLogInfoSkeleton.tsx
+++ b/src/features/strength/components/strength-log-info-skeleton/StrengthLogInfoSkeleton.tsx
@@ -1,0 +1,37 @@
+import styles from "../strength-log-info/StrengthLogInfo.module.css";
+import skeletonStyles from "./StrengthLogInfoSkeleton.module.css";
+import LoadingIndicator from "@/components/common/loading-indicator/LoadingIndicator";
+
+/**
+ * 冒険ログのローディングスケルトン
+ */
+const StrengthLogInfoSkeleton = () => {
+	return (
+		<div className={styles["strength-log-info"]}>
+			<div className={styles["strength-log-info-content"]}>
+				<div className={styles["strength-log-box"]}>
+					<h2 className={styles["strength-log-title"]}>冒険ログ</h2>
+					<div className={styles["strength-log-list-content"]}>
+						<div className={styles["strength-log-list-box"]}>
+							<ul className={`${styles["strength-log-list"]} ${skeletonStyles["skeleton-list"]}`}>
+								<li className={styles["strength-log-item"]}>
+									<div className={styles["strength-log-loading-text"]}>
+										<LoadingIndicator
+											text="読み込み中"
+											className={styles["loading-indicator"]}
+										/>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</div>
+					<div className={styles["strength-log-link-box"]}>
+						<span className={skeletonStyles["skeleton-link"]}>過去のログを全て確認する</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default StrengthLogInfoSkeleton;

--- a/src/features/strength/components/strength-log-info/StrengthLogInfo.module.css
+++ b/src/features/strength/components/strength-log-info/StrengthLogInfo.module.css
@@ -1,4 +1,5 @@
 .strength-log-info {
+	height: 100%;
 	border: 3mm ridge #b69973;
 	background-color: var(--color-primary-brown-dark);
 	border-radius: var(--border-radius-small);

--- a/src/features/strength/components/strength-log-info/StrengthLogInfo.tsx
+++ b/src/features/strength/components/strength-log-info/StrengthLogInfo.tsx
@@ -1,24 +1,21 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
 import styles from "./StrengthLogInfo.module.css";
-import { fetchZennArticles } from "@/features/posts/services";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useClickSound } from "@/components/common/audio/click-sound/ClickSound";
-import LoadingIndicator from "@/components/common/loading-indicator/LoadingIndicator";
+import type { FormattedLog } from "@/features/logs/services/logService";
 
-const StrengthLogInfo = () => {
-	const [logs, setLogs] = useState<string[]>([]);
-	const [loading, setLoading] = useState(true);
-	const [error, setError] = useState<string | null>(null);
-	const hasSynced = useRef(false);
+interface StrengthLogInfoProps {
+	logs: FormattedLog[];
+}
 
+const StrengthLogInfo = ({ logs }: StrengthLogInfoProps) => {
 	const router = useRouter();
 	const { playClickSound } = useClickSound({
 		soundPath: "/audio/click-sound_decision.mp3",
 		volume: 0.5,
-		delay: 190, // 190ミリ秒 = 0.19秒の遅延
+		delay: 190,
 	});
 
 	const handleNavigation = (e: React.MouseEvent<HTMLAnchorElement>, path: string) => {
@@ -26,105 +23,11 @@ const StrengthLogInfo = () => {
 		playClickSound(() => router.push(path));
 	};
 
-	useEffect(() => {
-		// コンポーネントマウント時に実行される
-		const initializeLogs = async () => {
-			if (hasSynced.current) return;
-			hasSynced.current = true;
-
-			try {
-				await syncAndFetchLogs();
-			} catch (err) {
-				console.error("ログの初期化エラー:", err);
-				setError("ログデータの初期化中にエラーが発生しました。");
-				setLoading(false);
-			}
-		};
-
-		initializeLogs();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []); // 依存配列は空のまま（初回マウント時のみ実行）
-
-	// ログを同期・取得する関数
-	const syncAndFetchLogs = async () => {
-		try {
-			setLoading(true);
-
-			// 1. Zennユーザー名取得
-			const userRes = await fetch("/api/user");
-			const userData = await userRes.json();
-			let username = "aoyamadev";
-			if (userData.success && userData.user.zennUsername) {
-				username = userData.user.zennUsername;
-			}
-
-			// 2. Zenn記事取得（すべての記事）
-			const articles = await fetchZennArticles(username, {
-				fetchAll: true,
-			});
-
-			// 3. ログ同期APIを呼び出し（記事データを送信してDBを更新）
-			await fetch("/api/logs/sync", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ articles }),
-			});
-
-			// 4. DBから最新のログを取得
-			const logsRes = await fetch("/api/logs");
-			const logsData = await logsRes.json();
-
-			if (logsData.success && Array.isArray(logsData.logs)) {
-				const formattedLogs = logsData.logs.map((log: any) => {
-					const date = new Date(log.occurredAt);
-					const formattedDate = formatDate(date);
-					return `${formattedDate} ${log.content}`;
-				});
-				setLogs(formattedLogs);
-			} else {
-				// ログがない場合
-				setLogs(generateDefaultLogs());
-			}
-		} catch (err) {
-			console.error("ログ同期エラー:", err);
-			// エラー時はデフォルトログ
-			setLogs(generateDefaultLogs());
-		} finally {
-			setLoading(false);
-		}
-	};
-
-	// 日付をフォーマットする関数
-	const formatDate = (date: Date): string => {
-		return `${date.getFullYear()}/${(date.getMonth() + 1)
-			.toString()
-			.padStart(2, "0")}/${date.getDate().toString().padStart(2, "0")} ${date
-			.getHours()
-			.toString()
-			.padStart(2, "0")}:${date.getMinutes().toString().padStart(2, "0")}:${date
-			.getSeconds()
-			.toString()
-			.padStart(2, "0")}`;
-	};
-
-	// デフォルトのログを生成
-	const generateDefaultLogs = (): string[] => {
-		return ["表示できる冒険ログはまだありません"];
-	};
-
-	// エラー表示
-	if (error) {
-		return (
-			<div className={styles["strength-log-info"]}>
-				<div className={styles["strength-log-info-content"]}>
-					<div className={styles["strength-log-box"]}>
-						<h2 className={styles["strength-log-title"]}>冒険ログ</h2>
-						<div className={styles["error-text"]}>{error}</div>
-					</div>
-				</div>
-			</div>
-		);
-	}
+	// ログがない場合のデフォルトメッセージ
+	const displayLogs =
+		logs.length > 0
+			? logs.slice(0, 15).map((log) => `${log.formattedDate} ${log.content}`)
+			: ["表示できる冒険ログはまだありません"];
 
 	return (
 		<div className={styles["strength-log-info"]}>
@@ -134,20 +37,11 @@ const StrengthLogInfo = () => {
 					<div className={styles["strength-log-list-content"]}>
 						<div className={styles["strength-log-list-box"]}>
 							<ul className={styles["strength-log-list"]}>
-								{loading ? (
-									<li className={styles["strength-log-item"]}>
-										<div className={styles["strength-log-loading-text"]}>
-											<LoadingIndicator text="読み込み中" className={styles["loading-indicator"]} />
-										</div>
+								{displayLogs.map((log, index) => (
+									<li key={index} className={styles["strength-log-item"]}>
+										<p className={styles["strength-log-text"]}>{log}</p>
 									</li>
-								) : (
-									// 最大15件のログのみ表示
-									logs.slice(0, 15).map((log, index) => (
-										<li key={index} className={styles["strength-log-item"]}>
-											<p className={styles["strength-log-text"]}>{log}</p>
-										</li>
-									))
-								)}
+								))}
 							</ul>
 						</div>
 					</div>

--- a/src/features/strength/components/strength-log-info/StrengthLogInfoWrapper.tsx
+++ b/src/features/strength/components/strength-log-info/StrengthLogInfoWrapper.tsx
@@ -1,0 +1,15 @@
+import { auth } from "@clerk/nextjs/server";
+import { getAdventureLogs } from "@/features/logs/services/logService";
+import StrengthLogInfo from "./StrengthLogInfo";
+
+/**
+ * サーバーコンポーネント：ログを取得してStrengthLogInfoに渡す
+ */
+const StrengthLogInfoWrapper = async () => {
+	const { userId } = await auth();
+	const logs = userId ? await getAdventureLogs(userId) : [];
+
+	return <StrengthLogInfo logs={logs} />;
+};
+
+export default StrengthLogInfoWrapper;


### PR DESCRIPTION
## Summary
- 冒険ログ（/strength, /logs）の取得ロジックをクライアントfetchからサーバーサイド直接DB取得に変更
- Zenn連携解除後のキャッシュ問題を解決し、ページ遷移ごとに最新データを取得
- Zenn未連携時は「表示できる冒険ログはまだありません」を正しく表示

## Changes
- `logService.ts`: `getAdventureLogs()`関数を追加
- `StrengthLogInfo`: props受け取り型に変更 + Wrapper追加
- `LogsList`: props受け取り型に変更 + Wrapper追加
- 各ページでSuspenseを使用してPartial Prerenderに対応

## Test plan
- [x] Zenn連携ユーザーで/strengthページにアクセスし、冒険ログが表示されることを確認
- [x] Zenn連携ユーザーで/logsページにアクセスし、冒険ログが表示されることを確認
- [x] Zenn未連携ユーザーで/strengthページにアクセスし、「表示できる冒険ログはまだありません」が表示されることを確認
- [x] Zenn未連携ユーザーで/logsページにアクセスし、「表示できる冒険ログはまだありません」が表示されることを確認
- [x] Zenn連携解除後、/strengthページに遷移してログが「表示できる冒険ログはまだありません」に更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)