### PR TITLE
perf(explore): ExplorePageClientのユーザー情報取得をサーバーサイドに移行

### DIFF
--- a/src/app/(main)/explore/page.tsx
+++ b/src/app/(main)/explore/page.tsx
@@ -4,8 +4,17 @@ import { getPageMetadata } from "@/config/metadata";
 import styles from "./ExplorePage.module.css";
 import * as Explore from "@/features/explore/components";
 import LoadingIndicator from "@/components/common/loading-indicator/LoadingIndicator";
+import { getUser } from "@/features/user/_lib/fetcher";
 
 export const metadata: Metadata = getPageMetadata("explore");
+
+// Server Componentでユーザー情報を取得するラッパー
+const ExplorePageContent = async () => {
+	const user = await getUser();
+	const initialZennUsername = user?.zennUsername ?? null;
+
+	return <Explore.ExplorePageClient initialZennUsername={initialZennUsername} />;
+};
 
 const ExplorePage = () => {
 	return (
@@ -20,7 +29,7 @@ const ExplorePage = () => {
 						</div>
 					}
 				>
-					<Explore.ExplorePageClient />
+					<ExplorePageContent />
 				</Suspense>
 			</div>
 		</>

--- a/src/features/explore/components/explore-page-client/ExplorePageClient.tsx
+++ b/src/features/explore/components/explore-page-client/ExplorePageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useUser } from "@clerk/nextjs";
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
@@ -30,12 +30,16 @@ const ExploreArticleAnalysis = dynamic(
 	}
 );
 
-const ExplorePageClient = () => {
+type Props = {
+	initialZennUsername: string | null;
+};
+
+const ExplorePageClient = ({ initialZennUsername }: Props) => {
 	const { user, isLoaded } = useUser();
-	const [userZennInfo, setUserZennInfo] = useState<{
-		zennUsername?: string;
-	} | null>(null);
-	const [isZennInfoLoaded, setIsZennInfoLoaded] = useState(false);
+	// サーバーサイドで取得した初期値を使用（useEffectでのフェッチ不要）
+	const [userZennInfo] = useState<{ zennUsername?: string } | null>(
+		initialZennUsername ? { zennUsername: initialZennUsername } : null
+	);
 	const [isAnalyzing, setIsAnalyzing] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
@@ -60,6 +64,7 @@ const ExplorePageClient = () => {
 	});
 
 	// ゲストユーザーまたはZenn未連携の場合
+	// サーバーサイドで取得した初期値を使用するため、isLoadedのみチェック
 	const isGuestUser = !isLoaded || !user || !userZennInfo?.zennUsername;
 
 	const handleAnalyzeArticles = async () => {
@@ -112,42 +117,6 @@ const ExplorePageClient = () => {
 		}
 	};
 
-	// ユーザーのZenn連携情報を取得
-	useEffect(() => {
-		const fetchUserZennInfo = async () => {
-			if (!isLoaded) {
-				setIsZennInfoLoaded(false);
-				return;
-			}
-
-			if (!user) {
-				setUserZennInfo(null);
-				setIsZennInfoLoaded(true);
-				return;
-			}
-
-			setIsZennInfoLoaded(false);
-
-			try {
-				const userRes = await fetch("/api/user");
-				const userData = await userRes.json();
-
-				if (userData.success) {
-					setUserZennInfo(userData.user);
-				} else {
-					setUserZennInfo(null);
-				}
-			} catch (err) {
-				console.error("ユーザー情報取得エラー:", err);
-				setUserZennInfo(null);
-			} finally {
-				setIsZennInfoLoaded(true);
-			}
-		};
-
-		fetchUserZennInfo();
-	}, [isLoaded, user?.id]);
-
 	return (
 		<>
 			<div className={`${styles["explorer-header"]}`}>
@@ -158,7 +127,7 @@ const ExplorePageClient = () => {
 						<p>あなたの成長に最適な「学びのタネ」を見つけ出します。</p>
 					</div>
 
-					{!isLoaded || !isZennInfoLoaded ? (
+					{!isLoaded ? (
 						<div className="grid place-items-center px-4">
 							<LoadingIndicator text="読み込み中" className={styles["loading-indicator"]} />
 						</div>
@@ -220,7 +189,7 @@ const ExplorePageClient = () => {
 			<ExploreArticleAnalysis
 				userZennInfo={userZennInfo}
 				isLoaded={isLoaded}
-				isZennInfoLoaded={isZennInfoLoaded}
+				isZennInfoLoaded={true}
 				messages={messages}
 				status={status}
 				isAnalyzing={isAnalyzing}


### PR DESCRIPTION
## Summary
- `ExplorePageClient`のユーザー情報取得をサーバーサイドに移行
- クライアントサイドの`useEffect`での`/api/user`フェッチを削除
- ネットワークウォーターフォールを排除

## Before
```tsx
// ExplorePageClient.tsx
useEffect(() => {
  const userRes = await fetch("/api/user"); // クライアントサイドでフェッチ
  // ...
}, [isLoaded, user?.id]);
```

## After
```tsx
// page.tsx (Server Component)
const ExplorePageContent = async () => {
  const user = await getUser(); // サーバーサイドでフェッチ
  return <ExplorePageClient initialZennUsername={user?.zennUsername ?? null} />;
};

// ExplorePageClient.tsx
const ExplorePageClient = ({ initialZennUsername }: Props) => {
  // useEffectでのフェッチ不要、propsで受け取った初期値を使用
};
```

## 期待効果
- ページロード時間短縮（サーバーから直接データ取得）
- クライアントJSバンドルサイズ削減（useEffect削除）
- ネットワークリクエスト数削減

## Test plan
- [ ] `/explore`ページにアクセスし、正常に表示されることを確認
- [ ] ログインユーザーで「探索する」ボタンが表示されることを確認
- [ ] ゲストユーザーで「ログインが必要」が表示されることを確認
- [ ] AI探索機能が正常に動作することを確認

Closes #35