### PR TITLE
perf(connection): ConnectionPageClientのユーザー情報取得をサーバーサイドに移行 #36

### DIFF
--- a/src/app/(main)/connection/page.tsx
+++ b/src/app/(main)/connection/page.tsx
@@ -1,9 +1,30 @@
+import { Suspense } from "react";
 import * as Connection from "@/features/connection/components";
 import { getPageMetadata } from "@/config/metadata";
 import { Metadata } from "next";
+import LoadingIndicator from "@/components/common/loading-indicator/LoadingIndicator";
+import { getUser } from "@/features/user/_lib/fetcher";
 
 export const metadata: Metadata = getPageMetadata("connection");
 
+// Server Componentでユーザー情報を取得するラッパー
+const ConnectionPageContent = async () => {
+	const user = await getUser();
+	const initialZennUsername = user?.zennUsername ?? null;
+
+	return <Connection.ConnectionPageClient initialZennUsername={initialZennUsername} />;
+};
+
 export default function ConnectionPage() {
-	return <Connection.ConnectionPageClient />;
+	return (
+		<Suspense
+			fallback={
+				<div className="grid place-items-center pt-4">
+					<LoadingIndicator text="読み込み中" />
+				</div>
+			}
+		>
+			<ConnectionPageContent />
+		</Suspense>
+	);
 }

--- a/src/features/connection/components/connection-page-client/ConnectionPageClient.tsx
+++ b/src/features/connection/components/connection-page-client/ConnectionPageClient.tsx
@@ -23,11 +23,16 @@ declare global {
 	}
 }
 
+type Props = {
+	initialZennUsername: string | null;
+};
+
 // ユーザープロフィールページ
-export default function ConnectionPageClient() {
+export default function ConnectionPageClient({ initialZennUsername }: Props) {
 	const { user, isLoaded } = useUser();
 	const router = useRouter();
-	const [zennUsername, setZennUsername] = useState("");
+	// サーバーサイドで取得した初期値を使用
+	const [zennUsername, setZennUsername] = useState(initialZennUsername ?? "");
 	const [wasLoggedOut, setWasLoggedOut] = useState(false);
 	const [isNewSession, setIsNewSession] = useState(false);
 
@@ -65,6 +70,7 @@ export default function ConnectionPageClient() {
 		setWasLoggedOut,
 		setIsNewSession,
 		setZennUsername,
+		initialZennUsername,
 	});
 
 	// Zenn連携管理

--- a/src/features/connection/hooks/useUserInfo.ts
+++ b/src/features/connection/hooks/useUserInfo.ts
@@ -9,6 +9,7 @@ interface UseUserInfoProps {
 	setWasLoggedOut: (value: boolean) => void;
 	setIsNewSession: (value: boolean) => void;
 	setZennUsername: (value: string) => void;
+	initialZennUsername?: string | null;
 }
 
 export const useUserInfo = ({
@@ -17,11 +18,16 @@ export const useUserInfo = ({
 	setWasLoggedOut,
 	setIsNewSession,
 	setZennUsername,
+	initialZennUsername,
 }: UseUserInfoProps) => {
 	const { user, isLoaded } = useUser();
-	const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
-	const [isZennInfoLoaded, setIsZennInfoLoaded] = useState(false);
-	const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
+	// サーバーサイドで取得した初期値がある場合、初期状態として使用
+	const hasInitialData = initialZennUsername !== undefined && initialZennUsername !== null;
+	const [userInfo, setUserInfo] = useState<UserInfo | null>(
+		hasInitialData ? { zennUsername: initialZennUsername } as UserInfo : null
+	);
+	const [isZennInfoLoaded, setIsZennInfoLoaded] = useState(hasInitialData);
+	const [hasLoadedOnce, setHasLoadedOnce] = useState(hasInitialData);
 
 	useEffect(() => {
 		const fetchAndSetUserInfo = async () => {


### PR DESCRIPTION
## Summary
- connection/page.tsxにServer Componentラッパーを追加
- getUser()でサーバーサイドでZennユーザー名を取得
- ConnectionPageClientにinitialZennUsername propsを追加
- useUserInfoに初期値オプションを追加し、初回のローディング状態を改善

## 改善内容
ExplorePageClient (#40)と同じパターンを適用:
1. **page.tsx**: getUser()でサーバーサイドでユーザー情報を取得
2. **ConnectionPageClient**: initialZennUsernameをpropsで受け取り、初期状態として使用
3. **useUserInfo**: 初期値がある場合、isZennInfoLoaded=trueで開始（ローディング状態をスキップ）

## Test plan
- [ ] /connectionページが正常に表示される
- [ ] ログイン済みユーザーのZenn連携状態が正しく表示される
- [ ] Zenn連携/解除の操作が正常に動作する

Closes #36