### PR TITLE
perf(title): TitlePageClientのユーザー情報取得をサーバーサイドに移行 #37

### DIFF
--- a/src/app/(main)/title/page.tsx
+++ b/src/app/(main)/title/page.tsx
@@ -1,16 +1,35 @@
+import { Suspense } from "react";
 import { Metadata } from "next";
 import { getPageMetadata } from "@/config/metadata";
 import styles from "./TitlePage.module.css";
 import * as Title from "@/features/title/components";
+import LoadingIndicator from "@/components/common/loading-indicator/LoadingIndicator";
+import { getUser } from "@/features/user/_lib/fetcher";
 
 export const metadata: Metadata = getPageMetadata("title");
+
+// Server Componentでユーザー情報を取得するラッパー
+const TitlePageContent = async () => {
+	const user = await getUser();
+	const initialZennUsername = user?.zennUsername ?? null;
+
+	return <Title.TitlePageClient initialZennUsername={initialZennUsername} />;
+};
 
 const TitlePage = () => {
 	return (
 		<>
 			<div className={styles["title-bg"]}></div>
 			<h1 className={`${styles["title-page-title"]}`}>称号リスト</h1>
-			<Title.TitlePageClient />
+			<Suspense
+				fallback={
+					<div className="grid place-items-center pt-4">
+						<LoadingIndicator text="読み込み中" />
+					</div>
+				}
+			>
+				<TitlePageContent />
+			</Suspense>
 		</>
 	);
 };

--- a/src/features/title/components/title-page-client/TitlePageClient.tsx
+++ b/src/features/title/components/title-page-client/TitlePageClient.tsx
@@ -1,57 +1,24 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useUser } from "@clerk/nextjs";
 import styles from "./TitlePageClient.module.css";
 import * as Title from "@/features/title/components";
 import LoadingIndicator from "@/components/common/loading-indicator/LoadingIndicator";
 
-const TitlePageClient = () => {
+type Props = {
+	initialZennUsername: string | null;
+};
+
+const TitlePageClient = ({ initialZennUsername }: Props) => {
 	const { user, isLoaded } = useUser();
-	const [userZennInfo, setUserZennInfo] = useState<{
-		zennUsername?: string;
-	} | null>(null);
-	const [isZennInfoLoaded, setIsZennInfoLoaded] = useState(false);
+	// サーバーサイドで取得した初期値を使用（useEffectでのフェッチ不要）
+	const [userZennInfo] = useState<{ zennUsername?: string } | null>(
+		initialZennUsername ? { zennUsername: initialZennUsername } : null
+	);
 
-	// ユーザーのZenn連携情報を取得
-	useEffect(() => {
-		const fetchUserZennInfo = async () => {
-			if (!isLoaded) {
-				// Clerkの認証状態がまだ確定していない場合は何もしない
-				setIsZennInfoLoaded(false);
-				return;
-			}
-
-			if (!user) {
-				// ユーザーがログインしていない場合
-				setUserZennInfo(null);
-				setIsZennInfoLoaded(true);
-				return;
-			}
-
-			// ユーザーがログイン済みの場合、Zenn情報を取得
-			try {
-				const response = await fetch("/api/user");
-				const data = await response.json();
-
-				if (data.success && data.user) {
-					setUserZennInfo({ zennUsername: data.user.zennUsername });
-				} else {
-					setUserZennInfo(null);
-				}
-			} catch (err) {
-				console.error("ユーザー情報取得エラー:", err);
-				setUserZennInfo(null);
-			} finally {
-				setIsZennInfoLoaded(true);
-			}
-		};
-
-		fetchUserZennInfo();
-	}, [isLoaded, user]);
-
-	// ロード中の判定
-	const isLoading = !isLoaded || (user && !isZennInfoLoaded);
+	// ロード中の判定（サーバーサイドで取得済みのため、Clerk認証状態のみ確認）
+	const isLoading = !isLoaded;
 
 	// ゲストユーザーかどうかの判定（Clerkサインイン + Zenn連携の両方が必要）
 	const isGuestUser = !user || !userZennInfo?.zennUsername;


### PR DESCRIPTION
## Summary
- title/page.tsxにServer Componentラッパーを追加
- getUser()でサーバーサイドでZennユーザー名を取得
- TitlePageClientのuseEffectを削除し、propsで初期値を受け取る形に変更

## 改善内容
ExplorePageClient (#40)、ConnectionPageClient (#41)と同じパターンを適用:
1. **page.tsx**: getUser()でサーバーサイドでユーザー情報を取得
2. **TitlePageClient**: useEffectを削除し、initialZennUsernameをpropsで受け取る

これにより/api/userへのクライアントサイドフェッチが不要になり、初回表示が高速化される。

## Test plan
- [ ] /titleページが正常に表示される
- [ ] ログイン済みユーザーは称号リストが表示される
- [ ] 未ログインユーザーはゲスト用メッセージが表示される

Closes #37