### PR TITLE
perf(posts): PostsListWithDataのキャッシュ最適化 #45

### DIFF
--- a/src/features/posts/components/posts-list-with-data/PostsListWithData.tsx
+++ b/src/features/posts/components/posts-list-with-data/PostsListWithData.tsx
@@ -1,4 +1,6 @@
-import { getUser } from "@/features/user/_lib/fetcher";
+import { connection } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
 import { getZennArticles } from "@/features/zenn/_lib/fetcher";
 import { PlatformType } from "@/features/posts/types";
 import * as Posts from "@/features/posts/components";
@@ -10,18 +12,38 @@ import styles from "./PostsListWithData.module.css";
  * Zenn記事一覧を取得して表示するServer Component
  *
  * データフェッチ:
- * - getUser(): 認証 + ユーザー情報取得（Request Memoization + use cache）
+ * - connection() + auth() + prisma: ユーザー認証とDB取得（動的）
  * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
+ *
+ * 注意: getUser()を使うとキャッシュの問題でユーザー間でデータが混在する
+ * 可能性があるため、認証関連は直接呼び出しを維持
  */
 const PostsListWithData = async () => {
+	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
+	await connection();
+
 	try {
-		// ユーザー情報を取得（getUser内でconnection() + auth() + prisma呼び出し）
-		const user = await getUser();
+		// 認証情報を取得
+		const { userId } = await auth();
 
-		// zennUsernameを取得（未設定の場合はデフォルト値）
-		const zennUsername = user?.zennUsername || "aoyamadev";
+		// ゲストユーザーの判定
+		let zennUsername = "aoyamadev"; // デフォルト値
 
-		// Zenn記事を取得（全件取得）
+		if (userId) {
+			// 認証済みユーザーの場合、DBからzennUsernameを取得
+			const user = await prisma.user.findUnique({
+				where: { clerkId: userId },
+				select: {
+					zennUsername: true,
+				},
+			});
+
+			if (user?.zennUsername) {
+				zennUsername = user.zennUsername;
+			}
+		}
+
+		// Zenn記事を取得（全件取得）- use cache + Request Memoization
 		const articles = await getZennArticles(zennUsername, { fetchAll: true });
 
 		// platformType: "zenn" を各記事に設定


### PR DESCRIPTION
## 概要
`PostsListWithData` のデータフェッチを最適化。

## 変更内容
- `getZennArticles()` を使用（Request Memoization + use cache 対応）
- 認証関連（`connection()` + `auth()` + `prisma`）は直接呼び出しを維持
- JSDoc コメント追加

## 注意点
`getUser()` を使用するとユーザー間でキャッシュが混在する問題が発生したため、認証関連は直接呼び出しを維持。

## 効果
- `getZennArticles()` による Zenn 記事取得が use cache + Request Memoization 対応
- 認証フローは正確に動作（ログインユーザーに応じた記事表示）

## 検証
- `pnpm build` 成功
- `/posts` が PPR（Partial Prerender）として生成
- ログインユーザー切り替え時に正しい記事が表示されることを確認

Close #45