### PR TITLE
perf(party): PartyMemberCardListのキャッシュ最適化 #46

### DIFF
--- a/src/features/party/components/party-member-card-list/PartyMemberCardList.tsx
+++ b/src/features/party/components/party-member-card-list/PartyMemberCardList.tsx
@@ -1,11 +1,23 @@
 import { connection } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { prisma } from "@/lib/prisma";
-import { fetchZennArticles } from "@/features/posts/services";
+import { getZennArticles } from "@/features/zenn/_lib/fetcher";
 import { updatePartyMembersByLevel } from "@/features/party/data/partyMemberData";
 import * as Party from "@/features/party/components";
 import styles from "./PartyMemberCardList.module.css";
 
+/**
+ * PartyMemberCardList (Server Component)
+ *
+ * パーティメンバー一覧を取得して表示するServer Component
+ *
+ * データフェッチ:
+ * - connection() + auth() + prisma: ユーザー認証とDB取得（動的）
+ * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
+ *
+ * 注意: getUser()を使うとキャッシュの問題でユーザー間でデータが混在する
+ * 可能性があるため、認証関連は直接呼び出しを維持
+ */
 const PartyMemberCardList = async () => {
 	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
 	await connection();
@@ -33,8 +45,8 @@ const PartyMemberCardList = async () => {
 			}
 		}
 
-		// Zenn記事を取得
-		const articles = await fetchZennArticles(zennUsername, { fetchAll: true });
+		// Zenn記事を取得（use cache + Request Memoization）
+		const articles = await getZennArticles(zennUsername, { fetchAll: true });
 		const articleCount = articles.length;
 
 		// パーティメンバーデータを更新


### PR DESCRIPTION
## 概要
`PartyMemberCardList` のZenn記事取得を `getZennArticles()` に統一。

## 変更内容
- `fetchZennArticles()` → `getZennArticles()` に変更
- Request Memoization + use cache によるキャッシュ最適化
- 認証関連（`connection()` + `auth()` + `prisma`）は直接呼び出しを維持
- JSDoc コメント追加

## 効果
- `getZennArticles()` による Zenn 記事取得が use cache + Request Memoization 対応
- 同一リクエスト内での重複フェッチを排除

## 検証
- `pnpm build` 成功
- `/party` が PPR（Partial Prerender）として生成

Close #46