### PR TITLE
perf(items): ItemCardListのキャッシュ最適化 #47

### DIFF
--- a/src/features/items/components/item-card-list/ItemCardList.tsx
+++ b/src/features/items/components/item-card-list/ItemCardList.tsx
@@ -1,11 +1,23 @@
 import { connection } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { prisma } from "@/lib/prisma";
-import { fetchZennArticles } from "@/features/posts/services";
+import { getZennArticles } from "@/features/zenn/_lib/fetcher";
 import { updateItemsByLevel } from "@/features/items/data/itemsData";
 import * as Items from "@/features/items/components";
 import styles from "./ItemCardList.module.css";
 
+/**
+ * ItemCardList (Server Component)
+ *
+ * アイテム一覧を取得して表示するServer Component
+ *
+ * データフェッチ:
+ * - connection() + auth() + prisma: ユーザー認証とDB取得（動的）
+ * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
+ *
+ * 注意: getUser()を使うとキャッシュの問題でユーザー間でデータが混在する
+ * 可能性があるため、認証関連は直接呼び出しを維持
+ */
 const ItemCardList = async () => {
 	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
 	await connection();
@@ -33,8 +45,8 @@ const ItemCardList = async () => {
 			}
 		}
 
-		// Zenn記事を取得
-		const articles = await fetchZennArticles(zennUsername, { fetchAll: true });
+		// Zenn記事を取得（use cache + Request Memoization）
+		const articles = await getZennArticles(zennUsername, { fetchAll: true });
 		const articleCount = articles.length;
 
 		// アイテムデータを更新


### PR DESCRIPTION
## 概要
`ItemCardList` のZenn記事取得を `getZennArticles()` に統一。

## 変更内容
- `fetchZennArticles()` → `getZennArticles()` に変更
- Request Memoization + use cache によるキャッシュ最適化
- 認証関連は直接呼び出しを維持
- JSDoc コメント追加

## 検証
- `pnpm build` 成功

Close #47