### PR TITLE
docs(strength): StrengthHeroInfoのJSDoc統一 #48

### DIFF
--- a/src/features/strength/components/strength-hero-info/StrengthHeroInfo.tsx
+++ b/src/features/strength/components/strength-hero-info/StrengthHeroInfo.tsx
@@ -13,10 +13,11 @@ import styles from "./StrengthHeroInfo.module.css";
  * ItemCardList/PartyMemberCardListと同じパターンで2層分離
  *
  * データフェッチ:
- * - auth() でユーザー認証
- * - prisma でzennUsername取得
- * - getZennArticles() で記事数取得（Request Memoization + "use cache"）
- * - レベル計算（記事数 = レベル）
+ * - connection() + auth() + prisma: ユーザー認証とDB取得（動的）
+ * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
+ *
+ * 注意: getUser()を使うとキャッシュの問題でユーザー間でデータが混在する
+ * 可能性があるため、認証関連は直接呼び出しを維持
  */
 const StrengthHeroInfo = async () => {
 	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）


### PR DESCRIPTION
## 概要
`StrengthHeroInfo` は既に最適化済みのため、JSDocコメントのみ統一。

## 変更内容
- 既に `getZennArticles()` を使用しており最適化済み
- JSDoc コメントを他のコンポーネントと統一
- `getUser()` に関する注意書きを追加

## 備考
コード変更なし。ドキュメントの一貫性のみ。

Close #48