### PR TITLE
docs(strength): StrengthTitleInfoのJSDoc統一 #49

### DIFF
--- a/src/features/strength/components/strength-title-info/StrengthTitleInfo.tsx
+++ b/src/features/strength/components/strength-title-info/StrengthTitleInfo.tsx
@@ -12,10 +12,11 @@ import styles from "./StrengthTitleInfo.module.css";
  * StrengthHeroInfoと同じパターンで2層分離
  *
  * データフェッチ:
- * - auth() でユーザー認証
- * - prisma でzennUsername取得
- * - getZennArticles() で記事数取得（Request Memoization + "use cache"）
- * - レベル計算（記事数 = レベル）
+ * - connection() + auth() + prisma: ユーザー認証とDB取得（動的）
+ * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
+ *
+ * 注意: getUser()を使うとキャッシュの問題でユーザー間でデータが混在する
+ * 可能性があるため、認証関連は直接呼び出しを維持
  */
 const StrengthTitleInfo = async () => {
 	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）


### PR DESCRIPTION
## 概要
`StrengthTitleInfo` は既に最適化済みのため、JSDocコメントのみ統一。

## 変更内容
- 既に `getZennArticles()` を使用しており最適化済み
- JSDoc コメントを他のコンポーネントと統一
- `getUser()` に関する注意書きを追加

## 備考
コード変更なし。ドキュメントの一貫性のみ。

Close #49