### PR TITLE
fix(logs): 冒険ログがログインユーザーに応じて切り替わらない問題を修正 #56

### DIFF
--- a/src/features/logs/components/logs-list/LogsListWrapper.tsx
+++ b/src/features/logs/components/logs-list/LogsListWrapper.tsx
@@ -1,15 +1,20 @@
 import { connection } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { getAdventureLogs } from "@/features/logs/services/logService";
+import { prisma } from "@/lib/prisma";
+import { getZennArticles } from "@/features/zenn/_lib/fetcher";
+import { getAdventureLogs, syncAdventureLogs } from "@/features/logs/services/logService";
 import LogsList from "./LogsList";
 
 /**
  * LogsListWrapper (Server Component)
  *
- * 冒険ログを取得してLogsListに渡す
+ * 冒険ログを同期・取得してLogsListに渡す
  *
  * データフェッチ:
  * - connection() + auth(): ユーザー認証（動的）
+ * - prisma: DBからユーザー情報取得
+ * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
+ * - syncAdventureLogs(): ログ同期
  * - getAdventureLogs(): DBからログ取得
  *
  * 注意: connection()を呼ばないとキャッシュされ、ユーザー間でデータが混在する
@@ -19,7 +24,28 @@ const LogsListWrapper = async () => {
 	await connection();
 
 	const { userId } = await auth();
-	const logs = userId ? await getAdventureLogs(userId) : [];
+
+	if (!userId) {
+		return <LogsList logs={[]} />;
+	}
+
+	// ユーザー情報を取得
+	const user = await prisma.user.findUnique({
+		where: { clerkId: userId },
+		select: { id: true, zennUsername: true },
+	});
+
+	// Zenn未連携の場合は空のログを表示
+	if (!user?.zennUsername) {
+		return <LogsList logs={[]} />;
+	}
+
+	// Zenn記事を取得してログを同期
+	const articles = await getZennArticles(user.zennUsername, { fetchAll: true });
+	await syncAdventureLogs(user.id, articles);
+
+	// 同期後のログを取得して表示
+	const logs = await getAdventureLogs(userId);
 
 	return <LogsList logs={logs} />;
 };

--- a/src/features/logs/services/logService.ts
+++ b/src/features/logs/services/logService.ts
@@ -7,7 +7,7 @@ import {
 import { titleNameData } from "@/shared/data/titleNameDate";
 
 interface Article {
-	id: number;
+	id: number | string;
 	title: string;
 	publishedAt?: string | null;
 	date?: string | Date;

--- a/src/features/strength/components/strength-log-info/StrengthLogInfoWrapper.tsx
+++ b/src/features/strength/components/strength-log-info/StrengthLogInfoWrapper.tsx
@@ -1,15 +1,20 @@
 import { connection } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { getAdventureLogs } from "@/features/logs/services/logService";
+import { prisma } from "@/lib/prisma";
+import { getZennArticles } from "@/features/zenn/_lib/fetcher";
+import { getAdventureLogs, syncAdventureLogs } from "@/features/logs/services/logService";
 import StrengthLogInfo from "./StrengthLogInfo";
 
 /**
  * StrengthLogInfoWrapper (Server Component)
  *
- * 冒険ログを取得してStrengthLogInfoに渡す
+ * 冒険ログを同期・取得してStrengthLogInfoに渡す
  *
  * データフェッチ:
  * - connection() + auth(): ユーザー認証（動的）
+ * - prisma: DBからユーザー情報取得
+ * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
+ * - syncAdventureLogs(): ログ同期
  * - getAdventureLogs(): DBからログ取得
  *
  * 注意: connection()を呼ばないとキャッシュされ、ユーザー間でデータが混在する
@@ -19,7 +24,28 @@ const StrengthLogInfoWrapper = async () => {
 	await connection();
 
 	const { userId } = await auth();
-	const logs = userId ? await getAdventureLogs(userId) : [];
+
+	if (!userId) {
+		return <StrengthLogInfo logs={[]} />;
+	}
+
+	// ユーザー情報を取得
+	const user = await prisma.user.findUnique({
+		where: { clerkId: userId },
+		select: { id: true, zennUsername: true },
+	});
+
+	// Zenn未連携の場合は空のログを表示
+	if (!user?.zennUsername) {
+		return <StrengthLogInfo logs={[]} />;
+	}
+
+	// Zenn記事を取得してログを同期
+	const articles = await getZennArticles(user.zennUsername, { fetchAll: true });
+	await syncAdventureLogs(user.id, articles);
+
+	// 同期後のログを取得して表示
+	const logs = await getAdventureLogs(userId);
 
 	return <StrengthLogInfo logs={logs} />;
 };


### PR DESCRIPTION
## 概要
aoyamadev以外のZennアカウントでログインしても、冒険ログがaoyamadevのログのまま表示される問題を修正。

## 根本原因
`syncAdventureLogs` 関数を呼び出すコードが存在しなかった。
- `/api/logs/sync` エンドポイントは存在したが、どこからも呼び出されていなかった
- ユーザーごとのログがDBに生成されておらず、他ユーザーのログが表示されていた

## 変更内容
- `LogsListWrapper`: ページ表示時にZenn記事を取得 → ログ同期 → ログ表示
- `StrengthLogInfoWrapper`: 同上
- `logService.ts`: `Article.id` の型を `number | string` に変更（PostDataとの互換性確保）

## 検証
- `pnpm build` 成功
- ログインユーザー切り替え時に正しいログが表示されることを確認してください

Closes #56