### PR TITLE
fix(storage): Cache Componentsモードのstorageアクセス制限に対応

### DIFF
--- a/src/features/connection/hooks/useMessageStorage.ts
+++ b/src/features/connection/hooks/useMessageStorage.ts
@@ -20,25 +20,29 @@ export const useMessageStorage = ({
 }: UseMessageStorageProps) => {
 	useEffect(() => {
 		if (typeof window !== "undefined") {
-			// 成功メッセージを取得
-			const savedSuccessMessage = localStorage.getItem(SUCCESS_MESSAGE_KEY);
-			if (savedSuccessMessage) {
-				setSuccess(savedSuccessMessage);
-				localStorage.removeItem(SUCCESS_MESSAGE_KEY);
-			}
+			try {
+				// 成功メッセージを取得
+				const savedSuccessMessage = localStorage.getItem(SUCCESS_MESSAGE_KEY);
+				if (savedSuccessMessage) {
+					setSuccess(savedSuccessMessage);
+					localStorage.removeItem(SUCCESS_MESSAGE_KEY);
+				}
 
-			// 連携解除メッセージを取得
-			const savedReleaseMessage = localStorage.getItem(RELEASE_MESSAGE_KEY);
-			if (savedReleaseMessage) {
-				setReleaseMessage(savedReleaseMessage);
-				localStorage.removeItem(RELEASE_MESSAGE_KEY);
-			}
+				// 連携解除メッセージを取得
+				const savedReleaseMessage = localStorage.getItem(RELEASE_MESSAGE_KEY);
+				if (savedReleaseMessage) {
+					setReleaseMessage(savedReleaseMessage);
+					localStorage.removeItem(RELEASE_MESSAGE_KEY);
+				}
 
-			// ログアウトフラグを確認
-			const logoutFlag = localStorage.getItem(LOGOUT_FLAG_KEY);
-			if (logoutFlag === "true") {
-				setWasLoggedOut(true);
-				localStorage.removeItem(LOGOUT_FLAG_KEY);
+				// ログアウトフラグを確認
+				const logoutFlag = localStorage.getItem(LOGOUT_FLAG_KEY);
+				if (logoutFlag === "true") {
+					setWasLoggedOut(true);
+					localStorage.removeItem(LOGOUT_FLAG_KEY);
+				}
+			} catch (error) {
+				// Cache Componentsモードでstorageアクセスが制限される場合は無視
 			}
 		}
 	}, [setSuccess, setReleaseMessage, setWasLoggedOut]);

--- a/src/features/connection/hooks/useSessionManagement.ts
+++ b/src/features/connection/hooks/useSessionManagement.ts
@@ -21,30 +21,34 @@ export const useSessionManagement = ({
 }: UseSessionManagementProps) => {
 	useEffect(() => {
 		if (typeof window !== "undefined") {
-			if (user) {
-				// ユーザーがログインしている場合
-				const currentSessionId = localStorage.getItem(SESSION_ID_KEY);
-				const logoutFlag = localStorage.getItem(LOGOUT_FLAG_KEY);
+			try {
+				if (user) {
+					// ユーザーがログインしている場合
+					const currentSessionId = localStorage.getItem(SESSION_ID_KEY);
+					const logoutFlag = localStorage.getItem(LOGOUT_FLAG_KEY);
 
-				// ログアウトフラグがある場合またはセッションIDが変更された場合
-				if (logoutFlag === "true" || !currentSessionId || currentSessionId !== user.id) {
-					// フラグをクリア
-					localStorage.removeItem(LOGOUT_FLAG_KEY);
-					localStorage.removeItem("zenn_previous_user");
-					localStorage.setItem(SESSION_ID_KEY, user.id);
+					// ログアウトフラグがある場合またはセッションIDが変更された場合
+					if (logoutFlag === "true" || !currentSessionId || currentSessionId !== user.id) {
+						// フラグをクリア
+						localStorage.removeItem(LOGOUT_FLAG_KEY);
+						localStorage.removeItem("zenn_previous_user");
+						localStorage.setItem(SESSION_ID_KEY, user.id);
 
-					// DBのデータは保持するため、リセット処理は行わない
-					// フラグのみ設定してuseUserInfoでDBから既存のデータを取得させる
-					setWasLoggedOut(true);
-					setIsNewSession(true);
+						// DBのデータは保持するため、リセット処理は行わない
+						// フラグのみ設定してuseUserInfoでDBから既存のデータを取得させる
+						setWasLoggedOut(true);
+						setIsNewSession(true);
+					}
+				} else if (isLoaded && !user) {
+					// ユーザーがログアウトしている場合はセッションIDを削除
+					localStorage.removeItem(SESSION_ID_KEY);
+					// ログアウト時にZennユーザー名をクリア（UIのみ）
+					setZennUsername("");
+					// ログアウト時に必ずフラグを設定
+					localStorage.setItem(LOGOUT_FLAG_KEY, "true");
 				}
-			} else if (isLoaded && !user) {
-				// ユーザーがログアウトしている場合はセッションIDを削除
-				localStorage.removeItem(SESSION_ID_KEY);
-				// ログアウト時にZennユーザー名をクリア（UIのみ）
-				setZennUsername("");
-				// ログアウト時に必ずフラグを設定
-				localStorage.setItem(LOGOUT_FLAG_KEY, "true");
+			} catch (error) {
+				// Cache Componentsモードでstorageアクセスが制限される場合は無視
 			}
 		}
 	}, [user, isLoaded, setWasLoggedOut, setIsNewSession, setZennUsername]);

--- a/src/features/connection/hooks/useSignOutHandler.ts
+++ b/src/features/connection/hooks/useSignOutHandler.ts
@@ -24,7 +24,11 @@ export const useSignOutHandler = ({
 		const handleBeforeUnload = () => {
 			// ユーザーがブラウザを閉じたり更新したりする際に、セッション情報を保持
 			if (user) {
-				localStorage.setItem(SESSION_ID_KEY, user.id);
+				try {
+					localStorage.setItem(SESSION_ID_KEY, user.id);
+				} catch (error) {
+					// Cache Componentsモードでstorageアクセスが制限される場合は無視
+				}
 			}
 		};
 
@@ -40,12 +44,16 @@ export const useSignOutHandler = ({
 		if (typeof window !== "undefined") {
 			// 同期的な連携解除実行関数
 			const syncResetZennConnection = () => {
-				// 確実にフラグを設定
-				localStorage.setItem(LOGOUT_FLAG_KEY, "true");
+				try {
+					// 確実にフラグを設定
+					localStorage.setItem(LOGOUT_FLAG_KEY, "true");
 
-				// 現在のユーザーIDを保存（ログ用）
-				if (user?.id) {
-					localStorage.setItem("zenn_previous_user", user.id);
+					// 現在のユーザーIDを保存（ログ用）
+					if (user?.id) {
+						localStorage.setItem("zenn_previous_user", user.id);
+					}
+				} catch (error) {
+					// Cache Componentsモードでstorageアクセスが制限される場合は無視
 				}
 
 				// 画面上の状態をクリア
@@ -62,21 +70,33 @@ export const useSignOutHandler = ({
 					syncResetZennConnection();
 
 					// 次にセッション関連の状態をクリア
-					localStorage.setItem(LOGOUT_FLAG_KEY, "true");
-					localStorage.removeItem(SESSION_ID_KEY);
+					try {
+						localStorage.setItem(LOGOUT_FLAG_KEY, "true");
+						localStorage.removeItem(SESSION_ID_KEY);
+					} catch (error) {
+						// Cache Componentsモードでstorageアクセスが制限される場合は無視
+					}
 
 					// DBのデータ（zennUsername、zennArticleCount、level）は一切変更しない
 					// 画面上の表示のみクリアする
 					// サインアウト後も次回ログイン時にZenn連携が維持されるようにする
 
 					// 最後の保険として、再度ログアウトフラグを設定
-					localStorage.setItem(LOGOUT_FLAG_KEY, "true");
-					localStorage.removeItem(SESSION_ID_KEY);
+					try {
+						localStorage.setItem(LOGOUT_FLAG_KEY, "true");
+						localStorage.removeItem(SESSION_ID_KEY);
+					} catch (error) {
+						// Cache Componentsモードでstorageアクセスが制限される場合は無視
+					}
 				} catch (err) {
 					console.error("サインアウトハンドラーエラー:", err);
 					// エラーが発生しても必ずログアウトフラグは維持する
-					localStorage.setItem(LOGOUT_FLAG_KEY, "true");
-					localStorage.removeItem(SESSION_ID_KEY);
+					try {
+						localStorage.setItem(LOGOUT_FLAG_KEY, "true");
+						localStorage.removeItem(SESSION_ID_KEY);
+					} catch (error) {
+						// Cache Componentsモードでstorageアクセスが制限される場合は無視
+					}
 				}
 			};
 

--- a/src/features/home/contexts/HomeAnimationContext.tsx
+++ b/src/features/home/contexts/HomeAnimationContext.tsx
@@ -21,15 +21,21 @@ export const HomeAnimationProvider = ({ children }: { children: ReactNode }) => 
 		// SSR中はsessionStorageにアクセスしない
 		if (typeof window === "undefined") return;
 
-		const hasVisited = sessionStorage.getItem("hero-visited");
+		try {
+			const hasVisited = sessionStorage.getItem("hero-visited");
 
-		if (hasVisited) {
-			setIsFirstVisit(false);
-			setIsAnimationStarted(true);
-			setIsImageVisible(true);
-		} else {
+			if (hasVisited) {
+				setIsFirstVisit(false);
+				setIsAnimationStarted(true);
+				setIsImageVisible(true);
+			} else {
+				setIsFirstVisit(true);
+				sessionStorage.setItem("hero-visited", "true");
+			}
+		} catch (error) {
+			// Cache Componentsモードでstorageアクセスが制限される場合は
+			// 初回訪問として扱う
 			setIsFirstVisit(true);
-			sessionStorage.setItem("hero-visited", "true");
 		}
 	}, []);
 

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -19,9 +19,8 @@ export function useLocalStorage<T>(key: string, initialValue: T): [T, Dispatch<S
 				localStorage.setItem(key, JSON.stringify(initialValue));
 			}
 		} catch (error) {
-			console.error(error);
-			// パースエラーの場合は初期値を使用
-			localStorage.setItem(key, JSON.stringify(initialValue));
+			// Cache Componentsモードでstorageアクセスが制限される場合は
+			// 初期値をそのまま使用
 		}
 	}, [key, initialValue]);
 
@@ -38,7 +37,7 @@ export function useLocalStorage<T>(key: string, initialValue: T): [T, Dispatch<S
 				localStorage.setItem(key, JSON.stringify(valueToStore));
 			}
 		} catch (error) {
-			console.error(error);
+			// Cache Componentsモードでstorageアクセスが制限される場合は無視
 		}
 	};
 


### PR DESCRIPTION
## 概要
本番環境で発生していた「Access to storage is not allowed from this context」エラーを修正

## 実装内容
localStorage/sessionStorageへの全アクセスをtry-catchで保護し、Cache Componentsモードでのstorageアクセス制限に対応

## 変更ファイル
- `HomeAnimationContext.tsx` - sessionStorageアクセスをtry-catchで保護
- `useSessionManagement.ts` - localStorageアクセスをtry-catchで保護
- `useSignOutHandler.ts` - localStorageアクセスをtry-catchで保護
- `useMessageStorage.ts` - localStorageアクセスをtry-catchで保護
- `useLocalStorage.ts` - catchブロック内のlocalStorage.setItemを削除、コメント統一

## テスト
- ✅ ビルド成功 (`pnpm build`)
- ✅ 型チェック通過

Fixes #59