### PR TITLE
fix(auth): ClerkProviderをClient Componentでラップ

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import { DotGothic16 } from "next/font/google";
-import { ClerkProvider } from "@clerk/nextjs";
+import { ClerkProviderWrapper } from "@/components/auth/clerk-provider-wrapper";
 import { baseMetadata } from "@/config/metadata";
 import type { Metadata } from "next";
 import { Header } from "@/components/layout/header/Header";
@@ -54,7 +54,7 @@ export default function RootLayout({
 				/>
 			</head>
 			<body suppressHydrationWarning>
-				<ClerkProvider
+				<ClerkProviderWrapper
 					signInFallbackRedirectUrl={redirectUrl}
 					signInForceRedirectUrl={redirectUrl}
 					signUpFallbackRedirectUrl={redirectUrl}
@@ -75,7 +75,7 @@ export default function RootLayout({
 							</HeroProvider>
 						</AudioProvider>
 					</SignOutHandler>
-				</ClerkProvider>
+				</ClerkProviderWrapper>
 			</body>
 		</html>
 	);

--- a/src/components/auth/clerk-provider-wrapper/ClerkProviderWrapper.tsx
+++ b/src/components/auth/clerk-provider-wrapper/ClerkProviderWrapper.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { ClerkProvider } from "@clerk/nextjs";
+
+interface ClerkProviderWrapperProps {
+	children: React.ReactNode;
+	signInFallbackRedirectUrl: string;
+	signInForceRedirectUrl: string;
+	signUpFallbackRedirectUrl: string;
+	signUpForceRedirectUrl: string;
+	afterSignOutUrl: string;
+}
+
+export const ClerkProviderWrapper = ({
+	children,
+	signInFallbackRedirectUrl,
+	signInForceRedirectUrl,
+	signUpFallbackRedirectUrl,
+	signUpForceRedirectUrl,
+	afterSignOutUrl,
+}: ClerkProviderWrapperProps) => {
+	return (
+		<ClerkProvider
+			signInFallbackRedirectUrl={signInFallbackRedirectUrl}
+			signInForceRedirectUrl={signInForceRedirectUrl}
+			signUpFallbackRedirectUrl={signUpFallbackRedirectUrl}
+			signUpForceRedirectUrl={signUpForceRedirectUrl}
+			afterSignOutUrl={afterSignOutUrl}
+		>
+			{children}
+		</ClerkProvider>
+	);
+};

--- a/src/components/auth/clerk-provider-wrapper/index.ts
+++ b/src/components/auth/clerk-provider-wrapper/index.ts
@@ -1,0 +1,1 @@
+export { ClerkProviderWrapper } from "./ClerkProviderWrapper";


### PR DESCRIPTION
## 概要

本番環境で発生していた「Access to storage is not allowed from this context」エラーを解消

## 原因

- `ClerkProvider` がServer Component（layout.tsx）で直接使用されていた
- Clerkは内部で `new Date()` とlocalStorage/sessionStorageを使用
- Cache Componentsモードのプリレンダリング中にこれらがエラーを引き起こしていた

## 解決策

- `ClerkProviderWrapper` をClient Componentとして作成
- layout.tsxで `ClerkProviderWrapper` を使用するように変更
- これによりClerkの処理がクライアントサイドでのみ実行される

## 変更ファイル

- `src/components/auth/clerk-provider-wrapper/ClerkProviderWrapper.tsx` (新規)
- `src/components/auth/clerk-provider-wrapper/index.ts` (新規)
- `src/app/layout.tsx` (修正)

## テスト

- ✅ ビルド成功 (`pnpm build`)
- ✅ 型チェック通過

Fixes #61