### PR TITLE
perf(image): ホームページ画像にpriority属性を追加

### DIFF
--- a/src/features/home/components/home-animated-crown/HomeAnimatedCrown.tsx
+++ b/src/features/home/components/home-animated-crown/HomeAnimatedCrown.tsx
@@ -17,7 +17,7 @@ const HomeAnimatedCrown = () => {
 				ease: "easeInOut",
 			}}
 		>
-			<Image src="/images/crown/crown01.png" alt="crown" width={100} height={100} />
+			<Image src="/images/crown/crown01.png" alt="crown" width={100} height={100} priority={true} />
 		</motion.div>
 	);
 };

--- a/src/features/home/components/home-start-button/HomeStartButton.tsx
+++ b/src/features/home/components/home-start-button/HomeStartButton.tsx
@@ -73,6 +73,7 @@ const HomeStartButton = () => {
 					width={1000}
 					height={1000}
 					className={styles["start-btn-image"]}
+					priority={true}
 				/>
 				<Image
 					src="/images/button/start-button/start-button-hover.png"
@@ -80,6 +81,7 @@ const HomeStartButton = () => {
 					width={1000}
 					height={1000}
 					className={styles["start-btn-image-hover"]}
+					priority={true}
 				/>
 			</Link>
 		</motion.div>


### PR DESCRIPTION
## Summary

- ホームページのファーストビュー画像に`priority={true}`を追加
- HomeAnimatedCrown: 王冠画像
- HomeStartButton: スタートボタン画像（通常・ホバー）

## 背景

Image priority 分析により、ファーストビューに表示される画像で`priority`が設定されていないものを特定。

### 修正対象（当初計画 vs 実際）

| ファイル | 計画 | 実際 |
|---------|------|------|
| `HomeAnimatedCrown.tsx` | 要修正 | ✅ 修正済み |
| `HomeStartButton.tsx` | 要修正 | ✅ 修正済み |
| `ItemDetailContent.tsx` | 要修正 | 既に設定済み |
| `PartyMemberDetailContent.tsx` | 要修正 | 既に設定済み |

## 期待される効果

- LCP（Largest Contentful Paint）の改善
- ホームページの初期表示速度向上

## Test plan

- [x] ホームページが正常に表示される
- [x] 王冠画像が遅延なく表示される
- [ ] スタートボタンが遅延なく表示される

Closes #65