### PR TITLE
perf(image): party/itemsページの画像プリロードを追加

### DIFF
--- a/src/app/(main)/items/ItemsPage.module.css
+++ b/src/app/(main)/items/ItemsPage.module.css
@@ -75,3 +75,12 @@
 		margin-inline: auto;
 	}
 }
+
+/* プリロード画像用（非表示） */
+.preload-images {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+}

--- a/src/app/(main)/items/page.tsx
+++ b/src/app/(main)/items/page.tsx
@@ -1,14 +1,46 @@
 import { Suspense } from "react";
 import { Metadata } from "next";
+import Image from "next/image";
 import { getPageMetadata } from "@/config/metadata";
 import styles from "./ItemsPage.module.css";
 import * as Items from "@/features/items/components";
+import {
+	customItemImages,
+	customItemSilhouetteImages,
+} from "@/features/items/data/itemsData";
 
 export const metadata: Metadata = getPageMetadata("items");
 
+// ファーストビュー用のプリロード画像（最初の8個分）
+const PRELOAD_ITEM_COUNT = 8;
+
 const ItemsPage = () => {
+	// プリロードする画像パスを生成
+	const preloadImages = [
+		// プレート画像（共通）
+		"/images/plate/plate01.png",
+		// 宝箱画像
+		"/images/items-page/treasure-chest-close.png",
+		"/images/items-page/treasure-chest-open.png",
+		// 最初の8個分のアイテム画像
+		...Object.entries(customItemImages)
+			.slice(0, PRELOAD_ITEM_COUNT)
+			.map(([, filename]) => `/images/items-page/acquired-icon/${filename}`),
+		// 最初の8個分のシルエット画像
+		...Object.entries(customItemSilhouetteImages)
+			.slice(0, PRELOAD_ITEM_COUNT)
+			.map(([, filename]) => `/images/items-page/unacquired-icon/${filename}`),
+	];
+
 	return (
 		<>
+			{/* Suspense 前に画像をプリロード（非表示） */}
+			<div aria-hidden="true" className={styles["preload-images"]}>
+				{preloadImages.map((src) => (
+					<Image key={src} src={src} width={1} height={1} alt="" priority />
+				))}
+			</div>
+
 			<div className={styles["title-bg"]}></div>
 			<h1 className={`${styles["items-title"]}`}>アイテム</h1>
 			<div className={`${styles["items-container"]}`}>

--- a/src/app/(main)/party/PartyPage.module.css
+++ b/src/app/(main)/party/PartyPage.module.css
@@ -75,3 +75,12 @@
 		margin-inline: auto;
 	}
 }
+
+/* プリロード画像用（非表示） */
+.preload-images {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+}

--- a/src/app/(main)/party/page.tsx
+++ b/src/app/(main)/party/page.tsx
@@ -1,14 +1,43 @@
 import { Suspense } from "react";
 import { Metadata } from "next";
+import Image from "next/image";
 import { getPageMetadata } from "@/config/metadata";
 import styles from "./PartyPage.module.css";
 import * as Party from "@/features/party/components";
+import {
+	customMemberImages,
+	customMemberSilhouetteImages,
+} from "@/features/party/data/partyMemberData";
 
 export const metadata: Metadata = getPageMetadata("party");
 
+// ファーストビュー用のプリロード画像（最初の8人分）
+const PRELOAD_MEMBER_COUNT = 8;
+
 const PartyPage = () => {
+	// プリロードする画像パスを生成
+	const preloadImages = [
+		// プレート画像（共通）
+		"/images/plate/plate01.png",
+		// 最初の8人分の仲間画像
+		...Object.entries(customMemberImages)
+			.slice(0, PRELOAD_MEMBER_COUNT)
+			.map(([, filename]) => `/images/party-page/acquired-icon/${filename}`),
+		// 最初の8人分のシルエット画像
+		...Object.entries(customMemberSilhouetteImages)
+			.slice(0, PRELOAD_MEMBER_COUNT)
+			.map(([, filename]) => `/images/party-page/unacquired-icon/${filename}`),
+	];
+
 	return (
 		<>
+			{/* Suspense 前に画像をプリロード（非表示） */}
+			<div aria-hidden="true" className={styles["preload-images"]}>
+				{preloadImages.map((src) => (
+					<Image key={src} src={src} width={1} height={1} alt="" priority />
+				))}
+			</div>
+
 			<div className={styles["title-bg"]}></div>
 			<h1 className={`${styles["party-title"]}`}>なかま</h1>
 			<div className={`${styles["party-container"]}`}>


### PR DESCRIPTION
## Summary
- `/party` と `/items` ページで、Suspense 境界の外で画像をプリロードするよう修正
- スケルトンUI表示中に画像のプリロードが開始され、UI解除時に画像が即座に表示されるように改善
- ファーストビュー用に最初の8件分の画像をプリロード

## Changes
- `src/app/(main)/party/page.tsx`: 仲間画像のプリロード処理を追加
- `src/app/(main)/items/page.tsx`: アイテム画像のプリロード処理を追加
- 両ページの CSS Module に `.preload-images` クラスを追加（非表示スタイル）

## Technical Details
### Before
1. スケルトンUI表示
2. Suspense 解除 → テキストのみ表示
3. 画像が遅れてロード（約1秒の遅延）

### After
1. スケルトンUI表示 + バックグラウンドで画像プリロード開始
2. Suspense 解除 → テキストと画像が同時に表示

## Test plan
- [ ] `/party` ページに遷移し、スケルトン解除時に画像が即座に表示されることを確認
- [ ] `/items` ページに遷移し、スケルトン解除時に画像が即座に表示されることを確認
- [ ] レイアウトが崩れていないことを確認
- [ ] TypeScript ビルドエラーがないことを確認

Fixes #67