### PR TITLE
refactor(detail): 詳細ページをServer Component + Suspenseパターンに変更

### DIFF
--- a/src/app/(main)/items/[itemId]/page.tsx
+++ b/src/app/(main)/items/[itemId]/page.tsx
@@ -1,7 +1,9 @@
+import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
 import styles from "./ItemDetailPage.module.css";
 import * as ItemDetail from "@/features/item-detail/components";
+import ItemDetailCard from "@/features/item-detail/components/item-detail-card/ItemDetailCard";
 import { generateItemMetadata } from "@/features/item-detail/metadata/generateItemMetadata";
 
 export async function generateStaticParams() {
@@ -36,8 +38,10 @@ export default async function ItemDetailPage({ params }: { params: Promise<{ ite
 
 			<h1 className={styles["item-detail-page-title"]}>アイテム詳細</h1>
 			<div className={styles["item-detail-container"]}>
-				{/* クライアントコンポーネント */}
-				<ItemDetail.ItemDetailContent itemId={itemIdNum} />
+				{/* Server Component + Suspense パターン */}
+				<Suspense fallback={<ItemDetail.ItemDetailSkeleton />}>
+					<ItemDetailCard itemId={itemIdNum} />
+				</Suspense>
 
 				<hr />
 

--- a/src/app/(main)/party/[partyId]/page.tsx
+++ b/src/app/(main)/party/[partyId]/page.tsx
@@ -1,7 +1,9 @@
+import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
 import styles from "./PartyMemberPage.module.css";
 import * as PartyMember from "@/features/party-member/components";
+import PartyMemberDetailCard from "@/features/party-member/components/party-member-detail-card/PartyMemberDetailCard";
 import { generatePartyMemberMetadata } from "@/features/party-member/metadata/generatePartyMemberMetadata";
 
 export async function generateStaticParams() {
@@ -41,8 +43,10 @@ export default async function PartyMemberPage({
 			<h1 className={`${styles["party-member-page-title"]}`}>なかま詳細</h1>
 
 			<div className={styles["party-member-container"]}>
-				{/* クライアントコンポーネント */}
-				<PartyMember.PartyMemberDetailContent partyId={partyIdNum} />
+				{/* Server Component + Suspense パターン */}
+				<Suspense fallback={<PartyMember.PartyMemberDetailSkeleton />}>
+					<PartyMemberDetailCard partyId={partyIdNum} />
+				</Suspense>
 
 				<hr />
 

--- a/src/features/item-detail/components/index.ts
+++ b/src/features/item-detail/components/index.ts
@@ -1,6 +1,15 @@
+// Server Components (ItemDetailCard) は barrel export できない
+// 直接 import する必要がある: import ItemDetailCard from "./item-detail-card/ItemDetailCard"
+import ItemDetailCardClient from "./item-detail-card-client/ItemDetailCardClient";
 import ItemDetailContent from "./item-detail-content/ItemDetailContent";
 import ItemDetailFooter from "./item-detail-footer/ItemDetailFooter";
 import ItemDetailSkeleton from "./item-detail-skeleton/ItemDetailSkeleton";
 import ItemDynamicHead from "./item-dynamic-head/ItemDynamicHead";
 
-export { ItemDetailContent, ItemDetailFooter, ItemDetailSkeleton, ItemDynamicHead };
+export {
+	ItemDetailCardClient,
+	ItemDetailContent,
+	ItemDetailFooter,
+	ItemDetailSkeleton,
+	ItemDynamicHead,
+};

--- a/src/features/item-detail/components/item-detail-card-client/ItemDetailCardClient.tsx
+++ b/src/features/item-detail/components/item-detail-card-client/ItemDetailCardClient.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Image from "next/image";
+import styles from "../item-detail-content/ItemDetailContent.module.css";
+import ItemDetailSkeleton from "../item-detail-skeleton/ItemDetailSkeleton";
+
+interface ItemDetailCardClientProps {
+	itemId: number;
+	isAcquired: boolean;
+	isGuestUser: boolean;
+	itemName: string | null;
+	itemDescription: string | null;
+	requiredLevel: number;
+	levelDifference: number;
+	acquiredImagePath: string;
+	unacquiredImagePath: string;
+}
+
+const ItemDetailCardClient: React.FC<ItemDetailCardClientProps> = ({
+	itemId,
+	isAcquired,
+	isGuestUser,
+	itemName,
+	itemDescription,
+	requiredLevel,
+	levelDifference,
+	acquiredImagePath,
+	unacquiredImagePath,
+}) => {
+	// スケルトンオーバーレイのフェードアウト用
+	const [showSkeleton, setShowSkeleton] = useState(true);
+
+	useEffect(() => {
+		// props が変わるたびにスケルトンを表示してフェードアウト
+		setShowSkeleton(true);
+		const timer = requestAnimationFrame(() => {
+			setShowSkeleton(false);
+		});
+		return () => cancelAnimationFrame(timer);
+	}, [itemId, isAcquired, isGuestUser]);
+
+	return (
+		<div className={styles["item-detail-content"]}>
+			<div className={styles["item-detail-card-wrapper"]}>
+				{/* 実コンテンツ */}
+				<div className={styles["item-detail-card"]}>
+					<Image
+						src="/images/card/card-bg.png"
+						alt="card background"
+						width={1000}
+						height={1000}
+						className={styles["item-detail-card-bg"]}
+						priority={true}
+					/>
+					<div className={styles["item-detail-card-content"]}>
+						<div className={styles["item-detail-image-box"]}>
+							{isAcquired ? (
+								<Image
+									src={acquiredImagePath}
+									alt={itemName || "アイテム"}
+									width={1000}
+									height={1000}
+									priority={true}
+									className={`${styles["item-detail-image"]} ${
+										styles[`item-detail-image-${itemId}`]
+									}`}
+								/>
+							) : (
+								<Image
+									src={unacquiredImagePath}
+									alt="未入手のアイテム"
+									width={60}
+									height={60}
+									priority={true}
+									className={`${styles["item-detail-image"]} ${
+										styles[`item-detail-image-${itemId}`]
+									}`}
+								/>
+							)}
+						</div>
+
+						<div className={styles["item-detail-title-box"]}>
+							<h2 className={styles["item-detail-title"]}>
+								{isAcquired ? itemName : "未入手のアイテム"}
+							</h2>
+						</div>
+
+						{isAcquired ? (
+							<div className={styles["item-detail-description-box"]}>
+								<p className={styles["item-detail-description"]}>{itemDescription}</p>
+							</div>
+						) : (
+							<div className={styles["item-detail-locked-message-box"]}>
+								{isGuestUser ? (
+									<p className={styles["item-detail-locked-message-text"]}>
+										ログインすると入手したアイテムについての詳細情報がここに表示されます。
+									</p>
+								) : (
+									<p className={styles["item-detail-locked-message-text"]}>
+										<span>このアイテムは、Lv{requiredLevel}で入手できるぞ！</span>
+										<span>
+											Lv{requiredLevel}まで、あと{levelDifference}レベル
+										</span>
+									</p>
+								)}
+							</div>
+						)}
+					</div>
+				</div>
+
+				{/* Skeletonオーバーレイ - フェードアウトアニメーション */}
+				<div
+					className={`${styles["skeleton-overlay"]} ${
+						showSkeleton ? styles["skeleton-overlay-visible"] : styles["skeleton-overlay-hidden"]
+					}`}
+				>
+					<ItemDetailSkeleton />
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default ItemDetailCardClient;

--- a/src/features/item-detail/components/item-detail-card/ItemDetailCard.module.css
+++ b/src/features/item-detail/components/item-detail-card/ItemDetailCard.module.css
@@ -1,0 +1,6 @@
+.error-message {
+	color: var(--color-primary-white);
+	text-align: center;
+	padding: 20px;
+	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
+}

--- a/src/features/item-detail/components/item-detail-card/ItemDetailCard.tsx
+++ b/src/features/item-detail/components/item-detail-card/ItemDetailCard.tsx
@@ -1,0 +1,102 @@
+import { connection } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+import { getZennArticles } from "@/features/zenn/_lib/fetcher";
+import {
+	isAcquiredByHeroLevel,
+	heroLevelAndItemRelation,
+	customItemNames,
+	customItemDescriptions,
+	customItemImages,
+	customItemSilhouetteImages,
+} from "@/features/items/data/itemsData";
+import ItemDetailCardClient from "../item-detail-card-client/ItemDetailCardClient";
+import styles from "./ItemDetailCard.module.css";
+
+interface ItemDetailCardProps {
+	itemId: number;
+}
+
+/**
+ * ItemDetailCard (Server Component)
+ *
+ * アイテム詳細データを取得して表示するServer Component
+ *
+ * データフェッチ:
+ * - connection() + auth() + prisma: ユーザー認証とDB取得（動的）
+ * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
+ */
+const ItemDetailCard = async ({ itemId }: ItemDetailCardProps) => {
+	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
+	await connection();
+
+	try {
+		// 認証情報を取得
+		const { userId } = await auth();
+
+		// ゲストユーザーの判定
+		let zennUsername = "aoyamadev"; // デフォルト値
+		let isGuestUser = true;
+		let currentLevel = 1;
+
+		if (userId) {
+			// 認証済みユーザーの場合、DBからzennUsernameを取得
+			const user = await prisma.user.findUnique({
+				where: { clerkId: userId },
+				select: {
+					zennUsername: true,
+				},
+			});
+
+			if (user?.zennUsername) {
+				zennUsername = user.zennUsername;
+				isGuestUser = false;
+
+				// Zenn記事を取得してレベルを計算
+				const articles = await getZennArticles(zennUsername, { fetchAll: true });
+				currentLevel = articles.length;
+			}
+		}
+
+		// アイテムの入手状態を判定
+		const isAcquired = !isGuestUser && isAcquiredByHeroLevel(itemId, currentLevel);
+
+		// アイテムを入手するために必要なレベル
+		const requiredLevel = heroLevelAndItemRelation[itemId] || itemId;
+
+		// レベル差を計算（マイナスにならないようにする）
+		const levelDifference = Math.max(0, requiredLevel - currentLevel);
+
+		// アイテムの名前と説明文を取得
+		const itemName = isAcquired ? customItemNames[itemId] || `アイテム${itemId}` : null;
+		const itemDescription = isAcquired
+			? customItemDescriptions[itemId] || `このアイテムの説明はありません。`
+			: null;
+
+		// 画像パスを取得
+		const acquiredImagePath = customItemImages[itemId]
+			? `/images/items-page/acquired-icon/${customItemImages[itemId]}`
+			: `/images/items-page/acquired-icon/item-${itemId}.png`;
+		const unacquiredImagePath = `/images/items-page/unacquired-icon/${customItemSilhouetteImages[itemId]}`;
+
+		// Client Componentにデータを渡す
+		return (
+			<ItemDetailCardClient
+				itemId={itemId}
+				isAcquired={isAcquired}
+				isGuestUser={isGuestUser}
+				itemName={itemName}
+				itemDescription={itemDescription}
+				requiredLevel={requiredLevel}
+				levelDifference={levelDifference}
+				acquiredImagePath={acquiredImagePath}
+				unacquiredImagePath={unacquiredImagePath}
+			/>
+		);
+	} catch (error) {
+		console.error("アイテム詳細データ取得エラー:", error);
+		return <p className={styles["error-message"]}>アイテム詳細データの取得に失敗しました。</p>;
+	}
+};
+
+export default ItemDetailCard;

--- a/src/features/item-detail/components/item-detail-skeleton/ItemDetailSkeleton.module.css
+++ b/src/features/item-detail/components/item-detail-skeleton/ItemDetailSkeleton.module.css
@@ -1,3 +1,14 @@
+.skeleton-wrapper {
+	display: grid;
+	place-items: center;
+	padding-inline: 25px;
+	padding-block: 40px;
+
+	@media (width < 1024px) {
+		padding-block: 20px;
+	}
+}
+
 .skeleton-card {
 	width: 360px;
 	height: 534.23px;

--- a/src/features/item-detail/components/item-detail-skeleton/ItemDetailSkeleton.tsx
+++ b/src/features/item-detail/components/item-detail-skeleton/ItemDetailSkeleton.tsx
@@ -2,7 +2,8 @@ import styles from "./ItemDetailSkeleton.module.css";
 
 const ItemDetailSkeleton = () => {
 	return (
-		<div className={styles["skeleton-card"]}>
+		<div className={styles["skeleton-wrapper"]}>
+			<div className={styles["skeleton-card"]}>
 			<div className={styles["skeleton-bg"]}>
 				<div className={styles["skeleton-card-content"]}>
 					{/* アイテム画像のスケルトン */}
@@ -21,6 +22,7 @@ const ItemDetailSkeleton = () => {
 					</div>
 				</div>
 			</div>
+		</div>
 		</div>
 	);
 };

--- a/src/features/party-member/components/index.ts
+++ b/src/features/party-member/components/index.ts
@@ -1,9 +1,13 @@
+// Server Components (PartyMemberDetailCard) は barrel export できない
+// 直接 import する必要がある: import PartyMemberDetailCard from "./party-member-detail-card/PartyMemberDetailCard"
+import PartyMemberDetailCardClient from "./party-member-detail-card-client/PartyMemberDetailCardClient";
 import PartyMemberDetailContent from "./party-member-detail-content/PartyMemberDetailContent";
 import PartyMemberDetailSkeleton from "./party-member-detail-skeleton/PartyMemberDetailSkeleton";
 import PartyMemberDynamicHead from "./party-member-dynamic-head/PartyMemberDynamicHead";
 import PartyMemberFooter from "./party-member-footer/PartyMemberFooter";
 
 export {
+	PartyMemberDetailCardClient,
 	PartyMemberDetailContent,
 	PartyMemberDetailSkeleton,
 	PartyMemberDynamicHead,

--- a/src/features/party-member/components/party-member-detail-card-client/PartyMemberDetailCardClient.tsx
+++ b/src/features/party-member/components/party-member-detail-card-client/PartyMemberDetailCardClient.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Image from "next/image";
+import styles from "../party-member-detail-content/PartyMemberDetailContent.module.css";
+import PartyMemberDetailSkeleton from "../party-member-detail-skeleton/PartyMemberDetailSkeleton";
+
+interface PartyMemberDetailCardClientProps {
+	partyId: number;
+	isAcquired: boolean;
+	isGuestUser: boolean;
+	memberName: string | null;
+	memberDescription: string | null;
+	requiredLevel: number;
+	levelDifference: number;
+	acquiredImagePath: string;
+	unacquiredImagePath: string;
+}
+
+const PartyMemberDetailCardClient: React.FC<PartyMemberDetailCardClientProps> = ({
+	partyId,
+	isAcquired,
+	isGuestUser,
+	memberName,
+	memberDescription,
+	requiredLevel,
+	levelDifference,
+	acquiredImagePath,
+	unacquiredImagePath,
+}) => {
+	// スケルトンオーバーレイのフェードアウト用
+	const [showSkeleton, setShowSkeleton] = useState(true);
+
+	useEffect(() => {
+		// props が変わるたびにスケルトンを表示してフェードアウト
+		setShowSkeleton(true);
+		const timer = requestAnimationFrame(() => {
+			setShowSkeleton(false);
+		});
+		return () => cancelAnimationFrame(timer);
+	}, [partyId, isAcquired, isGuestUser]);
+
+	return (
+		<div className={styles["party-member-content"]}>
+			<div className={styles["party-member-card-wrapper"]}>
+				{/* 実コンテンツ */}
+				<div className={styles["party-member-card"]}>
+					<Image
+						src="/images/card/card-bg.png"
+						alt="card background"
+						width={1000}
+						height={1000}
+						className={styles["party-member-card-bg"]}
+						priority={true}
+					/>
+					<div className={styles["party-member-card-content"]}>
+						<div className={styles["party-member-image-box"]}>
+							{isAcquired ? (
+								<Image
+									src={acquiredImagePath}
+									alt={memberName || "勇者の仲間"}
+									width={1000}
+									height={1000}
+									priority={true}
+									className={`${styles["party-member-image"]} ${
+										styles[`party-member-image-${partyId}`]
+									}`}
+								/>
+							) : (
+								<Image
+									src={unacquiredImagePath}
+									alt="まだ見ぬ仲間"
+									width={60}
+									height={60}
+									priority={true}
+									className={`${styles["party-member-image"]} ${
+										styles[`party-member-image-${partyId}`]
+									}`}
+								/>
+							)}
+						</div>
+
+						<div className={styles["party-member-title-box"]}>
+							<h2 className={styles["party-member-title"]}>
+								{isAcquired ? memberName : "まだ見ぬ仲間"}
+							</h2>
+						</div>
+
+						{isAcquired ? (
+							<div className={styles["party-member-description-box"]}>
+								<p className={styles["party-member-description"]}>{memberDescription}</p>
+							</div>
+						) : (
+							<div className={styles["party-member-locked-message-box"]}>
+								{isGuestUser ? (
+									<p className={styles["party-member-locked-message-text"]}>
+										ログインすると勇者の仲間に加わったキャラクターの詳細情報がここに表示されます。
+									</p>
+								) : (
+									<p className={styles["party-member-locked-message-text"]}>
+										<span>このキャラはLv{requiredLevel}で仲間に加わるぞ！</span>
+										<span>
+											Lv{requiredLevel}まで、あと{levelDifference}レベル
+										</span>
+									</p>
+								)}
+							</div>
+						)}
+					</div>
+				</div>
+
+				{/* Skeletonオーバーレイ - フェードアウトアニメーション */}
+				<div
+					className={`${styles["skeleton-overlay"]} ${
+						showSkeleton ? styles["skeleton-overlay-visible"] : styles["skeleton-overlay-hidden"]
+					}`}
+				>
+					<PartyMemberDetailSkeleton />
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default PartyMemberDetailCardClient;

--- a/src/features/party-member/components/party-member-detail-card/PartyMemberDetailCard.module.css
+++ b/src/features/party-member/components/party-member-detail-card/PartyMemberDetailCard.module.css
@@ -1,0 +1,6 @@
+.error-message {
+	color: var(--color-primary-white);
+	text-align: center;
+	padding: 20px;
+	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
+}

--- a/src/features/party-member/components/party-member-detail-card/PartyMemberDetailCard.tsx
+++ b/src/features/party-member/components/party-member-detail-card/PartyMemberDetailCard.tsx
@@ -1,0 +1,100 @@
+import { connection } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+import { getZennArticles } from "@/features/zenn/_lib/fetcher";
+import {
+	isAcquiredByHeroLevel,
+	heroLevelAndMemberRelation,
+	customMemberNames,
+	customMemberDescriptions,
+	customMemberImages,
+	customMemberSilhouetteImages,
+} from "@/features/party/data/partyMemberData";
+import PartyMemberDetailCardClient from "../party-member-detail-card-client/PartyMemberDetailCardClient";
+import styles from "./PartyMemberDetailCard.module.css";
+
+interface PartyMemberDetailCardProps {
+	partyId: number;
+}
+
+/**
+ * PartyMemberDetailCard (Server Component)
+ *
+ * なかま詳細データを取得して表示するServer Component
+ *
+ * データフェッチ:
+ * - connection() + auth() + prisma: ユーザー認証とDB取得（動的）
+ * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
+ */
+const PartyMemberDetailCard = async ({ partyId }: PartyMemberDetailCardProps) => {
+	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
+	await connection();
+
+	try {
+		// 認証情報を取得
+		const { userId } = await auth();
+
+		// ゲストユーザーの判定
+		let zennUsername = "aoyamadev"; // デフォルト値
+		let isGuestUser = true;
+		let currentLevel = 1;
+
+		if (userId) {
+			// 認証済みユーザーの場合、DBからzennUsernameを取得
+			const user = await prisma.user.findUnique({
+				where: { clerkId: userId },
+				select: {
+					zennUsername: true,
+				},
+			});
+
+			if (user?.zennUsername) {
+				zennUsername = user.zennUsername;
+				isGuestUser = false;
+
+				// Zenn記事を取得してレベルを計算
+				const articles = await getZennArticles(zennUsername, { fetchAll: true });
+				currentLevel = articles.length;
+			}
+		}
+
+		// 仲間の入手状態を判定
+		const isAcquired = !isGuestUser && isAcquiredByHeroLevel(partyId, currentLevel);
+
+		// 仲間を入手するために必要なレベル
+		const requiredLevel = heroLevelAndMemberRelation[partyId] || partyId;
+
+		// レベル差を計算（マイナスにならないようにする）
+		const levelDifference = Math.max(0, requiredLevel - currentLevel);
+
+		// 仲間の名前と説明文を取得
+		const memberName = isAcquired ? customMemberNames[partyId] || `勇者の仲間${partyId}` : null;
+		const memberDescription = isAcquired
+			? customMemberDescriptions[partyId] || `このキャラクターの説明はありません。`
+			: null;
+
+		// 画像パスを取得
+		const acquiredImagePath = `/images/party-page/acquired-icon/${customMemberImages[partyId]}`;
+		const unacquiredImagePath = `/images/party-page/unacquired-icon/${customMemberSilhouetteImages[partyId]}`;
+
+		// Client Componentにデータを渡す
+		return (
+			<PartyMemberDetailCardClient
+				partyId={partyId}
+				isAcquired={isAcquired}
+				isGuestUser={isGuestUser}
+				memberName={memberName}
+				memberDescription={memberDescription}
+				requiredLevel={requiredLevel}
+				levelDifference={levelDifference}
+				acquiredImagePath={acquiredImagePath}
+				unacquiredImagePath={unacquiredImagePath}
+			/>
+		);
+	} catch (error) {
+		console.error("なかま詳細データ取得エラー:", error);
+		return <p className={styles["error-message"]}>なかま詳細データの取得に失敗しました。</p>;
+	}
+};
+
+export default PartyMemberDetailCard;

--- a/src/features/party-member/components/party-member-detail-skeleton/PartyMemberDetailSkeleton.module.css
+++ b/src/features/party-member/components/party-member-detail-skeleton/PartyMemberDetailSkeleton.module.css
@@ -1,3 +1,14 @@
+.skeleton-wrapper {
+	display: grid;
+	place-items: center;
+	padding-inline: 25px;
+	padding-block: 40px;
+
+	@media (width < 1024px) {
+		padding-block: 20px;
+	}
+}
+
 .skeleton-card {
 	width: 360px;
 	height: 534.23px;

--- a/src/features/party-member/components/party-member-detail-skeleton/PartyMemberDetailSkeleton.tsx
+++ b/src/features/party-member/components/party-member-detail-skeleton/PartyMemberDetailSkeleton.tsx
@@ -2,7 +2,8 @@ import styles from "./PartyMemberDetailSkeleton.module.css";
 
 const PartyMemberDetailSkeleton = () => {
 	return (
-		<div className={styles["skeleton-card"]}>
+		<div className={styles["skeleton-wrapper"]}>
+			<div className={styles["skeleton-card"]}>
 			<div className={styles["skeleton-bg"]}>
 				<div className={styles["skeleton-card-content"]}>
 					{/* メンバー画像のスケルトン */}
@@ -21,6 +22,7 @@ const PartyMemberDetailSkeleton = () => {
 					</div>
 				</div>
 			</div>
+		</div>
 		</div>
 	);
 };


### PR DESCRIPTION
## Summary
- `/items/[itemId]` と `/party/[partyId]` 詳細ページをServer Component + Suspenseパターンにリファクタリング
- データ取得をクライアントサイド（useEffect）からサーバーサイドに移動
- パフォーマンス向上とベストプラクティスに準拠

## Changes
### 新規ファイル
- `ItemDetailCard.tsx` - Server Component（データ取得担当）
- `ItemDetailCardClient.tsx` - Client Component（UI表示担当）
- `PartyMemberDetailCard.tsx` - Server Component（データ取得担当）
- `PartyMemberDetailCardClient.tsx` - Client Component（UI表示担当）

### 変更ファイル
- `items/[itemId]/page.tsx` - Suspenseパターンに変更
- `party/[partyId]/page.tsx` - Suspenseパターンに変更
- `ItemDetailSkeleton` - 中央配置用ラッパー追加
- `PartyMemberDetailSkeleton` - 中央配置用ラッパー追加

## Test plan
- [ ] `/items/1` ～ `/items/30` でレイアウトが正常に表示される
- [ ] `/party/1` ～ `/party/30` でレイアウトが正常に表示される
- [ ] スケルトン → 実コンテンツのフェードアウトアニメーションが動作する
- [ ] 一覧ページからの遷移でも正しく動作する

closes #70