### PR TITLE
fix(eslint): ESLint 9 flat config構造へ移行しcircular structure errorを解決

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,25 +1,24 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
-import pluginPrettier from "eslint-plugin-prettier";
-import eslintConfigPrettier from "eslint-config-prettier";
+import { defineConfig, globalIgnores } from "eslint/config";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTs from "eslint-config-next/typescript";
+import prettier from "eslint-config-prettier/flat";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-	baseDirectory: __dirname,
-});
-
-const eslintConfig = [
-	// Ignore auto‑generated code (e.g., Prisma client & runtime) so ESLint
-	// doesn’t block builds with warnings we don’t control.
-	{
-		ignores: ["src/generated/**"],
-	},
-	...compat.extends("next/core-web-vitals", "next/typescript"),
-	pluginPrettier.configs.recommended,
-	eslintConfigPrettier,
-];
+const eslintConfig = defineConfig([
+	...nextVitals,
+	...nextTs,
+	prettier,
+	// Override default ignores of eslint-config-next + add project-specific ignores
+	globalIgnores([
+		// Default ignores of eslint-config-next:
+		".next/**",
+		"out/**",
+		"build/**",
+		"next-env.d.ts",
+		// Project-specific ignores:
+		// Ignore auto-generated code (e.g., Prisma client & runtime) so ESLint
+		// doesn't block builds with warnings we don't control.
+		"src/generated/**",
+	]),
+]);
 
 export default eslintConfig;


### PR DESCRIPTION
## 概要
Issue #64で報告されたESLint circular structure errorを解決しました。

## 問題
`pnpm lint:fix`実行時に以下のエラーが発生していました：
```
TypeError: Converting circular structure to JSON
```

原因は、`FlatCompat`を使用した旧形式の設定と`eslint-plugin-prettier/recommended`の組み合わせでした。

## 修正内容
Next.js 16公式推奨のESLint 9 flat config構造に移行しました：

### Before
```javascript
import { FlatCompat } from "@eslint/eslintrc";
...compat.extends("next/core-web-vitals", "next/typescript")
eslintPluginPrettierRecommended  // ← circular structure発生
```

### After
```javascript
import { defineConfig, globalIgnores } from "eslint/config";
import nextVitals from "eslint-config-next/core-web-vitals";
import nextTs from "eslint-config-next/typescript";
import prettier from "eslint-config-prettier/flat";
```

## 変更詳細
- ✅ `FlatCompat`を削除し、`defineConfig` + `globalIgnores`に移行
- ✅ `eslint-config-next/core-web-vitals`と`typescript`を直接import
- ✅ `eslint-config-prettier/flat`を使用してPrettierとの統合
- ✅ Prisma生成コードのignoreを`globalIgnores`に統合
- ✅ Next.js 16公式ドキュメントに準拠した設定

## 検証
\`pnpm lint:fix\`が正常に動作することを確認しました。
circular structure errorは完全に解決され、実際のコードのlintエラー/warningが正しく検出されるようになりました。

## 備考
今回のPRではESLint設定の修正のみを行っています。
検出された41個のlintエラー/warning（16 errors, 25 warnings）の修正は別issueで対応予定です。

Fixes #64