### PR TITLE
feat(ui): /items・/partyページにスケルトンUIフェードアウトトランジションを追加

### DIFF
--- a/src/features/items/components/item-card-list-client/ItemCardListClient.module.css
+++ b/src/features/items/components/item-card-list-client/ItemCardListClient.module.css
@@ -1,16 +1,10 @@
 .items-grid {
-	grid-area: grid;
 	display: block grid;
 	grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
 	height: 100%;
 	gap: 40px;
-	overflow-y: scroll;
 	padding-block: 30px 20px;
 	padding-inline: 20px;
-
-	@media (width < 1024px) {
-		overflow-y: visible;
-	}
 }
 
 .item-card-content {
@@ -268,4 +262,33 @@
 	background-color: #ae926e;
 	padding-block: 1px 3px;
 	padding-inline: 15px;
+}
+
+/* グリッドとスケルトンを重ねるラッパー */
+.items-grid-wrapper {
+	display: block grid;
+	grid-area: grid;
+	height: 100%;
+	overflow: scroll;
+
+	& > * {
+		grid-area: 1 / 1;
+	}
+}
+
+/* Skeletonオーバーレイ */
+.skeleton-overlay {
+	z-index: 10;
+	transition: opacity 0.3s ease-out;
+	pointer-events: none;
+}
+
+.skeleton-overlay-visible {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+.skeleton-overlay-hidden {
+	opacity: 0;
+	pointer-events: none;
 }

--- a/src/features/items/components/item-card-list-client/ItemCardListClient.tsx
+++ b/src/features/items/components/item-card-list-client/ItemCardListClient.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import styles from "./ItemCardListClient.module.css";
@@ -6,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { useClickSound } from "@/components/common/audio/click-sound/ClickSound";
 import { Item } from "@/features/items/types/items.types";
 import { customItemSilhouetteImages } from "@/features/items/data/itemsData";
+import ItemListSkeleton from "../item-list-skeleton/ItemListSkeleton";
 
 interface ItemCardListClientProps {
 	items: Item[];
@@ -19,6 +21,17 @@ const ItemCardListClient: React.FC<ItemCardListClientProps> = ({ items, isGuestU
 		volume: 0.5,
 		delay: 190,
 	});
+	const [isLoading, setIsLoading] = useState(true);
+
+	// マウント後、最小表示時間を経てスケルトンをフェードアウト
+	// Suspenseのfallbackからの滑らかな切り替えを実現するため
+	useEffect(() => {
+		const MINIMUM_SKELETON_DISPLAY_MS = 300;
+		const timerId = setTimeout(() => {
+			setIsLoading(false);
+		}, MINIMUM_SKELETON_DISPLAY_MS);
+		return () => clearTimeout(timerId);
+	}, []);
 
 	const handleNavigation = (e: React.MouseEvent<HTMLAnchorElement>, path: string) => {
 		e.preventDefault();
@@ -26,7 +39,9 @@ const ItemCardListClient: React.FC<ItemCardListClientProps> = ({ items, isGuestU
 	};
 
 	return (
-		<div className={styles["items-grid"]}>
+		<div className={styles["items-grid-wrapper"]}>
+			{/* 実コンテンツ - 常にマウント（priority属性が効く） */}
+			<div className={styles["items-grid"]}>
 			{items.map((item) => (
 				<div className={styles["item-card-content"]} key={item.id}>
 					<Link
@@ -106,6 +121,16 @@ const ItemCardListClient: React.FC<ItemCardListClientProps> = ({ items, isGuestU
 					</Link>
 				</div>
 			))}
+			</div>
+
+			{/* Skeletonオーバーレイ - ローディング時のみ表示 */}
+			<div
+				className={`${styles["skeleton-overlay"]} ${
+					isLoading ? styles["skeleton-overlay-visible"] : styles["skeleton-overlay-hidden"]
+				}`}
+			>
+				<ItemListSkeleton />
+			</div>
 		</div>
 	);
 };

--- a/src/features/items/components/item-list-skeleton/ItemListSkeleton.module.css
+++ b/src/features/items/components/item-list-skeleton/ItemListSkeleton.module.css
@@ -40,8 +40,8 @@
 }
 
 .skeleton-name {
-	width: 80%;
-	height: 30px;
+	width: 60%;
+	height: 50px;
 	border-radius: 4px;
 	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
 	background-size: 200% 100%;

--- a/src/features/party/components/party-list-skeleton/PartyListSkeleton.module.css
+++ b/src/features/party/components/party-list-skeleton/PartyListSkeleton.module.css
@@ -46,8 +46,8 @@
 }
 
 .skeleton-name {
-	width: 80%;
-	height: 30px; /* 名前ボックスの高さに合わせる */
+	width: 60%;
+	height: 50px;
 	border-radius: 4px;
 	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
 	background-size: 200% 100%;

--- a/src/features/party/components/party-member-card-list-client/PartyMemberCardListClient.module.css
+++ b/src/features/party/components/party-member-card-list-client/PartyMemberCardListClient.module.css
@@ -1,16 +1,10 @@
 .party-grid {
-	grid-area: grid;
 	display: block grid;
 	grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
 	height: 100%;
 	gap: 40px;
-	overflow-y: scroll;
 	padding-block: 30px 20px;
 	padding-inline: 20px;
-
-	@media (width < 1024px) {
-		overflow-y: visible;
-	}
 }
 
 .party-member-card-content {
@@ -152,4 +146,33 @@
 	background-color: #ae926e;
 	padding-block: 1px 3px;
 	padding-inline: 15px;
+}
+
+/* グリッドとスケルトンを重ねるラッパー */
+.party-grid-wrapper {
+	display: block grid;
+	grid-area: grid;
+	height: 100%;
+	overflow: scroll;
+
+	& > * {
+		grid-area: 1 / 1;
+	}
+}
+
+/* Skeletonオーバーレイ */
+.skeleton-overlay {
+	z-index: 10;
+	transition: opacity 0.3s ease-out;
+	pointer-events: none;
+}
+
+.skeleton-overlay-visible {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+.skeleton-overlay-hidden {
+	opacity: 0;
+	pointer-events: none;
 }

--- a/src/features/party/components/party-member-card-list-client/PartyMemberCardListClient.tsx
+++ b/src/features/party/components/party-member-card-list-client/PartyMemberCardListClient.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import styles from "./PartyMemberCardListClient.module.css";
 import Image from "next/image";
@@ -6,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { useClickSound } from "@/components/common/audio/click-sound/ClickSound";
 import { PartyMember } from "@/features/party/types/party.types";
 import { customMemberSilhouetteImages } from "@/features/party/data/partyMemberData";
+import PartyListSkeleton from "../party-list-skeleton/PartyListSkeleton";
 
 interface PartyMemberCardListClientProps {
 	members: PartyMember[];
@@ -22,6 +24,17 @@ const PartyMemberCardListClient: React.FC<PartyMemberCardListClientProps> = ({
 		volume: 0.5,
 		delay: 190,
 	});
+	const [isLoading, setIsLoading] = useState(true);
+
+	// マウント後、最小表示時間を経てスケルトンをフェードアウト
+	// Suspenseのfallbackからの滑らかな切り替えを実現するため
+	useEffect(() => {
+		const MINIMUM_SKELETON_DISPLAY_MS = 300;
+		const timerId = setTimeout(() => {
+			setIsLoading(false);
+		}, MINIMUM_SKELETON_DISPLAY_MS);
+		return () => clearTimeout(timerId);
+	}, []);
 
 	const handleNavigation = (e: React.MouseEvent<HTMLAnchorElement>, path: string) => {
 		e.preventDefault();
@@ -29,7 +42,9 @@ const PartyMemberCardListClient: React.FC<PartyMemberCardListClientProps> = ({
 	};
 
 	return (
-		<div className={styles["party-grid"]}>
+		<div className={styles["party-grid-wrapper"]}>
+			{/* 実コンテンツ - 常にマウント（priority属性が効く） */}
+			<div className={styles["party-grid"]}>
 			{members.map((partyMember) => (
 				<div className={styles["party-member-card-content"]} key={partyMember.id}>
 					<Link
@@ -88,6 +103,16 @@ const PartyMemberCardListClient: React.FC<PartyMemberCardListClientProps> = ({
 					</Link>
 				</div>
 			))}
+			</div>
+
+			{/* Skeletonオーバーレイ - ローディング時のみ表示 */}
+			<div
+				className={`${styles["skeleton-overlay"]} ${
+					isLoading ? styles["skeleton-overlay-visible"] : styles["skeleton-overlay-hidden"]
+				}`}
+			>
+				<PartyListSkeleton />
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
## Summary
- `/items`・`/party`ページのスケルトンUIから実コンテンツへの切り替え時に滑らかなフェードアウトトランジション（0.3s ease-out）を追加
- ItemDetailContentで実装済みのオーバーレイパターンを踏襲
- Suspense fallbackと内部スケルトンの組み合わせでUX/パフォーマンスとアニメーション両立

## 実装内容
- CSS Gridを使用してコンテンツとスケルトンを重ね合わせ
- `opacity 0.3s ease-out`によるスムーズなフェードアウト効果
- 最小表示時間300msを設定しSuspense fallbackからのシームレスな切り替えを実現

## 変更ファイル
- `src/features/items/components/item-card-list-client/ItemCardListClient.tsx`
- `src/features/items/components/item-card-list-client/ItemCardListClient.module.css`
- `src/features/party/components/party-member-card-list-client/PartyMemberCardListClient.tsx`
- `src/features/party/components/party-member-card-list-client/PartyMemberCardListClient.module.css`

## Test plan
- [ ] `/items`ページでスケルトン→実コンテンツのフェードアウトを確認
- [ ] `/party`ページでスケルトン→実コンテンツのフェードアウトを確認
- [ ] スクロールが正常に動作することを確認

Closes #75