### PR TITLE
fix(ui): ConnectionZennInfoDisplayの投稿数表示にLoadingIndicatorを適用

### DIFF
--- a/src/features/connection/components/connection-zenn-info-display/ConnectionZennInfoDisplay.tsx
+++ b/src/features/connection/components/connection-zenn-info-display/ConnectionZennInfoDisplay.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import styles from "./ConnectionZennInfoDisplay.module.css";
+import LoadingIndicator from "@/components/common/loading-indicator/LoadingIndicator";
 
 interface UserInfo {
 	id: string;
@@ -47,7 +48,11 @@ const ConnectionZennInfoDisplay: React.FC<ConnectionZennInfoDisplayProps> = ({
 							<span className={styles["article-count-title-text"]}>投稿した記事：</span>
 						</dt>
 						<dd className={styles["article-count-description"]}>
-							{loading ? "..." : userInfo.zennArticleCount}件
+							{loading ? (
+								<LoadingIndicator text="" />
+							) : (
+								<>{userInfo.zennArticleCount}件</>
+							)}
 						</dd>
 					</dl>
 				</div>


### PR DESCRIPTION
## Summary
- `/connection`ページのZenn連携情報セクションで、投稿数のローディング表示を改善
- 静的な`"..."`をアニメーション付きの`LoadingIndicator`コンポーネントに置き換え

## 変更内容
```tsx
// Before
{loading ? "..." : userInfo.zennArticleCount}件

// After
{loading ? <LoadingIndicator text="" /> : <>{userInfo.zennArticleCount}件</>}
```

## Test plan
- [x] `/connection`ページでZenn連携情報の投稿数がローディング中にアニメーション表示されることを確認

Closes #77