### PR TITLE
refactor: API Routesから不要な思考プロセスコメントを削除

### DIFF
--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -23,12 +23,6 @@ export async function GET() {
 			orderBy: { occurredAt: "desc" },
 		});
 
-		// Map to string array for compatibility with current UI expectations if needed?
-		// Or return full objects.
-		// Current UI expects string[].
-		// But new UI might want more details (type, etc).
-		// For now, let's return the objects, and the client can format them.
-
 		return NextResponse.json({ success: true, logs });
 	} catch (error) {
 		console.error("Fetch logs error:", error);

--- a/src/app/api/logs/sync/route.ts
+++ b/src/app/api/logs/sync/route.ts
@@ -10,12 +10,6 @@ export async function POST(request: Request) {
 			return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
 		}
 
-		// Find user in DB (we need the DB ID, not Clerk ID for existing check?
-		// Actually logService uses userId. Schema says userId is a String referncing User.id.
-		// Wait, User model: id (uuid), clerkId (String @unique).
-		// logs.userId refers to User.id.
-		// So we must fetch User.id via clerkId.
-
 		const user = await prisma.user.findUnique({
 			where: { clerkId: userId },
 			select: { id: true },

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -176,9 +176,6 @@ export async function POST(request: Request) {
 					?.emailAddress || clerkUser.emailAddresses[0]?.emailAddress;
 
 			if (!emailFromClerk) {
-				// emailFromClerk が undefined の場合、エラーを投げるか、
-				// デフォルトのメールアドレスを設定するなどの対応が必要
-				// ここではエラーを投げる例を示す
 				throw new Error("Clerkからメールアドレスが取得できませんでした。");
 			}
 


### PR DESCRIPTION
## Summary

- API Routesに残っていた開発時の思考プロセスコメントを削除
- コードをクリーンにし、可読性を向上

## 変更内容

| ファイル | 削除内容 |
|---------|---------|
| `api/logs/sync/route.ts` | User model構造の検討コメント（5行） |
| `api/logs/route.ts` | 戻り値形式の検討コメント（5行） |
| `api/user/route.ts` | エラー処理の選択肢コメント（3行） |

## Test plan

- [x] `pnpm build` でビルドエラーがないことを確認
- [x] 機能への影響がないことを確認（コメント削除のみ）

Closes #82