### PR TITLE
fix: 存在しない画像パスの参照を修正 (#84)

### DIFF
--- a/src/app/(main)/items/page.tsx
+++ b/src/app/(main)/items/page.tsx
@@ -16,9 +16,6 @@ const ItemsPage = () => {
 	const preloadImages = [
 		// プレート画像（共通）
 		"/images/plate/plate01.png",
-		// 宝箱画像
-		"/images/items-page/treasure-chest-close.png",
-		"/images/items-page/treasure-chest-open.png",
 		// 最初の8個分のアイテム画像
 		...Object.entries(customItemImages)
 			.slice(0, PRELOAD_ITEM_COUNT)

--- a/src/features/gnav/components/gnav-items/GnavItems.tsx
+++ b/src/features/gnav/components/gnav-items/GnavItems.tsx
@@ -39,7 +39,7 @@ const GnavItems = () => {
 									className={`${styles["gnav-item-content"]} ${isActive ? styles["gnav-item-content-active"] : ""}`}
 								>
 									<Image
-										src={item.icon || "/images/nav-icon/default-icon.svg"}
+										src={item.icon}
 										alt={item.alt || item.title}
 										width={item.width || 20}
 										height={item.height || 20}

--- a/src/features/item-detail/components/item-dynamic-head/ItemDynamicHead.tsx
+++ b/src/features/item-detail/components/item-dynamic-head/ItemDynamicHead.tsx
@@ -92,7 +92,7 @@ const ItemDynamicHead: React.FC<ItemDynamicHeadProps> = ({ itemId }) => {
 			const guestDescription =
 				"ログインすると入手したアイテムについての詳細情報がここに表示されます。";
 			const guestOgTitle = `${guestTitle}｜OUTPUT QUEST`;
-			const guestImageUrl = "/images/items-page/unacquired-icon/treasure-chest.svg";
+			const guestImageUrl = "/images/items-page/unacquired-icon/treasure-chest-close-icon01.png";
 
 			// 基本メタデータ
 			if (titleElement) titleElement.textContent = `${guestTitle}｜OUTPUT QUEST`;
@@ -151,7 +151,7 @@ const ItemDynamicHead: React.FC<ItemDynamicHeadProps> = ({ itemId }) => {
 				: itemId;
 			const unacquiredDescription = `このアイテムはレベル${requiredLevel}で入手できます。冒険を続けて探索しましょう。`;
 			const unacquiredOgTitle = `${unacquiredTitle}｜アイテム詳細`;
-			const unacquiredImageUrl = "/images/items-page/unacquired-icon/treasure-chest.svg";
+			const unacquiredImageUrl = "/images/items-page/unacquired-icon/treasure-chest-close-icon01.png";
 
 			// 基本メタデータ
 			if (titleElement) titleElement.textContent = `${unacquiredTitle}｜OUTPUT QUEST`;

--- a/src/features/items/components/item-card-list-client/ItemCardListClient.module.css
+++ b/src/features/items/components/item-card-list-client/ItemCardListClient.module.css
@@ -30,17 +30,6 @@
 		.unacquired-item-icon-image {
 			transform: translateY(-5px);
 		}
-
-		/* 宝箱アイコンのホバー制御 */
-		.treasure-chest-close {
-			opacity: 0;
-			scale: 0.8;
-		}
-
-		.treasure-chest-open {
-			opacity: 1;
-			scale: 1;
-		}
 	}
 }
 
@@ -225,25 +214,6 @@
 .acquired-item-icon-image-30,
 .unacquired-item-icon-image-30 {
 	width: 135px;
-}
-
-/* 宝箱の開閉スタイル（既存のスタイルを維持または調整） */
-.treasure-chest-close,
-.treasure-chest-open {
-	width: 100%;
-	height: auto;
-	transition:
-		opacity 0.2s ease-in-out,
-		transform 0.2s ease-in-out,
-		scale 0.2s ease-in-out;
-	position: absolute; /* 重ねて表示するためにabsoluteにする */
-	inset: 0;
-	margin: auto;
-}
-
-.treasure-chest-open {
-	opacity: 0;
-	scale: 0.8;
 }
 
 .item-name-box {


### PR DESCRIPTION
## Summary

- コード内で参照されているが実際には存在しない画像パスを修正
- 4ファイルを修正、合計36行削除

## 変更内容

| ファイル | 修正内容 |
|---------|---------|
| `src/app/(main)/items/page.tsx` | 存在しないtreasure-chest PNGをプリロードリストから削除 |
| `src/features/item-detail/.../ItemDynamicHead.tsx` | 削除済みの`treasure-chest.svg`を`treasure-chest-close-icon01.png`に変更 |
| `src/features/gnav/.../GnavItems.tsx` | 到達不能なフォールバックパスを削除（`icon`は必須プロパティ） |
| `src/features/items/.../ItemCardListClient.module.css` | 未使用の`.treasure-chest-close`/`.treasure-chest-open`クラスを削除 |

## 関連Issue

Closes #84

## Test plan

- [x] `pnpm build` でビルドが成功することを確認
- [x] `pnpm dev` でアイテムページを確認し、400エラーが解消されていることを確認
- [x] ナビゲーションアイコンが正常に表示されることを確認