### PR TITLE
refactor(css): ハードコードされたカラー値をCSS変数化 (#87)

### DIFF
--- a/src/components/auth/auth-button/AuthButton.module.css
+++ b/src/components/auth/auth-button/AuthButton.module.css
@@ -6,8 +6,8 @@
 	border-radius: var(--border-radius-small);
 	padding-block: 2.5px;
 	padding-inline: 2.5px;
-	background-color: #5a4734;
-	border: 2.5px solid #b69973;
+	background-color: var(--color-bg-button);
+	border: 2.5px solid var(--color-border-primary);
 	cursor: pointer;
 
 	&:hover {
@@ -26,7 +26,7 @@
 	position: relative;
 	display: block flow;
 	width: 100%;
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 1.5px solid var(--color-primary-brown-light);
 	padding-block: 10px 11px;
 	padding-inline: 15px;

--- a/src/components/auth/user-icon-button/UserIconButton.module.css
+++ b/src/components/auth/user-icon-button/UserIconButton.module.css
@@ -24,7 +24,7 @@
 	height: 100px;
 	order: 1;
 	background-color: var(--color-primary-brown-dark);
-	border: 3.5px solid #b69973;
+	border: 3.5px solid var(--color-border-primary);
 	border-radius: var(--border-rounded);
 	background-clip: border-box;
 	padding-inline: 3px;

--- a/src/components/common/titled-section/TitledSection.module.css
+++ b/src/components/common/titled-section/TitledSection.module.css
@@ -7,7 +7,7 @@
 .title-container {
 	width: fit-content;
 	background-color: var(--color-primary-brown-dark);
-	border: 2mm ridge #b69973;
+	border: 2mm ridge var(--color-border-primary);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
 }

--- a/src/features/about/components/about-section-title/AboutSectionTitle.module.css
+++ b/src/features/about/components/about-section-title/AboutSectionTitle.module.css
@@ -1,6 +1,6 @@
 .about-section-title-container {
 	background-color: var(--color-primary-brown-dark);
-	border: 2mm ridge #b69973;
+	border: 2mm ridge var(--color-border-primary);
 	width: fit-content;
 	padding-inline: 2.5px;
 	padding-block: 2.5px;

--- a/src/features/connection-detail/components/connection-detail-content/ConnectionDetailContent.module.css
+++ b/src/features/connection-detail/components/connection-detail-content/ConnectionDetailContent.module.css
@@ -22,7 +22,7 @@
 }
 
 .connection-detail-content-inner {
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	background-color: var(--color-primary-brown-dark);
 	padding-block: 2.5px;
 	padding-inline: 2.5px;

--- a/src/features/connection/components/connection-auth-section/ConnectionAuthSection.module.css
+++ b/src/features/connection/components/connection-auth-section/ConnectionAuthSection.module.css
@@ -23,8 +23,8 @@
 	border-radius: var(--border-radius-small);
 	padding-block: 2.5px;
 	padding-inline: 2.5px;
-	background-color: #5a4734;
-	border: 2.5px solid #b69973;
+	background-color: var(--color-bg-button);
+	border: 2.5px solid var(--color-border-primary);
 
 	&.active:hover {
 		.connect-button-content {
@@ -36,7 +36,7 @@
 .connect-button-content {
 	width: 100%;
 	height: 100%;
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 1.5px solid var(--color-primary-brown-light);
 	place-items: center;
 	padding-block: 5px;

--- a/src/features/connection/components/connection-zenn-form/ConnectionZennForm.module.css
+++ b/src/features/connection/components/connection-zenn-form/ConnectionZennForm.module.css
@@ -8,8 +8,8 @@
 	border-radius: var(--border-radius-small);
 	padding-block: 2.5px;
 	padding-inline: 2.5px;
-	background-color: #5a4734;
-	border: 2.5px solid #b69973;
+	background-color: var(--color-bg-button);
+	border: 2.5px solid var(--color-border-primary);
 
 	&.active:hover {
 		.connect-button-content {
@@ -19,7 +19,7 @@
 }
 
 .connect-button-content {
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 1.5px solid var(--color-primary-brown-light);
 	place-items: center;
 	padding-block: 5px;

--- a/src/features/connection/components/connection-zenn-info-display/ConnectionZennInfoDisplay.module.css
+++ b/src/features/connection/components/connection-zenn-info-display/ConnectionZennInfoDisplay.module.css
@@ -4,7 +4,7 @@
 	max-width: 100%;
 	margin-inline: auto;
 	margin-block-start: 10px;
-	border: 4mm ridge #b69973;
+	border: 4mm ridge var(--color-border-primary);
 	background-color: var(--color-primary-brown-dark);
 	padding-inline: 3px;
 	padding-block: 3px;
@@ -19,7 +19,7 @@
 	place-items: center;
 	gap: 20px;
 	border: 2px solid var(--color-primary-brown-light);
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	padding-inline: 20px;
 	padding-block: 15px 25px;
 
@@ -41,7 +41,7 @@
 	font-size: 0.875rem;
 	font-weight: var(--font-weight-normal);
 	line-height: var(--leading-x-tight);
-	border: 2px solid #b69973;
+	border: 2px solid var(--color-border-primary);
 	padding-block: 7px 8px;
 	padding-inline: 15px;
 

--- a/src/features/dashboard/components/dashboard-activity-content/DashboardActivityContent.module.css
+++ b/src/features/dashboard/components/dashboard-activity-content/DashboardActivityContent.module.css
@@ -46,7 +46,7 @@
 	display: block flex;
 	justify-content: space-between;
 	align-items: center;
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	background-color: var(--color-primary-brown-dark);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
@@ -56,7 +56,7 @@
 	width: 100%;
 	display: block grid;
 	color: var(--color-primary-white);
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 2px solid var(--color-primary-brown-light);
 	padding-inline: 15px;
 	padding-block: 12px 10px;
@@ -109,7 +109,7 @@
 	font-weight: var(--font-weight-x-bold);
 	line-height: var(--leading-none);
 	letter-spacing: 0.025em;
-	border: 2px solid #b69973;
+	border: 2px solid var(--color-border-primary);
 	padding-inline: 8.5px;
 	padding-block: 5.5px;
 }

--- a/src/features/dashboard/components/dashboard-activity-skeleton/DashboardActivitySkeleton.module.css
+++ b/src/features/dashboard/components/dashboard-activity-skeleton/DashboardActivitySkeleton.module.css
@@ -45,7 +45,7 @@
 	display: block flex;
 	justify-content: space-between;
 	align-items: center;
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
 	/* border-radius: var(--border-radius-small); */
@@ -57,7 +57,7 @@
 	width: 100%;
 	display: block grid;
 	color: var(--color-primary-white);
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 2px solid var(--color-primary-brown-light);
 	padding-inline: 15px;
 	padding-block: 12px 10px;
@@ -74,7 +74,7 @@
 .skeleton-activity-item-title {
 	width: 85%;
 	height: 27px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;
@@ -95,7 +95,7 @@
 .skeleton-category {
 	width: 60px;
 	height: 28px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;
@@ -105,7 +105,7 @@
 .skeleton-date {
 	width: 100px;
 	height: 28px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;
@@ -123,7 +123,7 @@
 .skeleton-favicon {
 	width: 14px;
 	height: 14px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 2px;
@@ -133,7 +133,7 @@
 .skeleton-platform {
 	width: 40px;
 	height: 14px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 2px;
@@ -145,7 +145,7 @@
 	height: 24px;
 	display: block grid;
 	place-self: end;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;

--- a/src/features/dashboard/components/dashboard-hero-section/DashboardHeroSection.module.css
+++ b/src/features/dashboard/components/dashboard-hero-section/DashboardHeroSection.module.css
@@ -75,7 +75,7 @@
 .hero-info-name-box {
 	grid-area: name;
 	background-color: var(--color-primary-brown-dark);
-	border: 1.5mm ridge #b69973;
+	border: 1.5mm ridge var(--color-border-primary);
 	padding-block: 1.5px;
 	padding-inline: 1.5px;
 }
@@ -86,7 +86,7 @@
 	line-height: var(--leading-tight);
 	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
 	border: 1px solid var(--color-primary-brown-light);
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	align-items: center;
 	gap: 5px;
 	padding-block: 2px 3px;
@@ -161,7 +161,7 @@
 
 .hero-info-level-display-container {
 	background-color: var(--color-primary-brown-dark);
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	width: min-content;
 	height: 105px;
 	padding-block: 2.5px;
@@ -175,7 +175,7 @@
 }
 
 .hero-info-level-display-box {
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 2px solid var(--color-primary-brown-light);
 	place-content: center;
 	place-items: center;

--- a/src/features/dashboard/components/dashboard-hero-skeleton/DashboardHeroSkeleton.module.css
+++ b/src/features/dashboard/components/dashboard-hero-skeleton/DashboardHeroSkeleton.module.css
@@ -77,7 +77,7 @@
 .skeleton-hero-icon {
 	width: 100%;
 	height: 100%;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	background-color: var(--color-primary-brown);
@@ -97,7 +97,7 @@
 .skeleton-hero-name {
 	width: 140px;
 	height: 28px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border: 1px solid var(--color-primary-brown-light);
@@ -132,11 +132,11 @@
 	height: 105px;
 	display: grid;
 	place-self: end;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	background-color: var(--color-primary-brown-dark);
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 
 	@media (max-width: 767px) {
 		place-self: center;
@@ -147,7 +147,7 @@
 .skeleton-hero-share {
 	width: 80px;
 	height: 20px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;
@@ -163,7 +163,7 @@
 .skeleton-hero-progress-text {
 	height: 24px;
 	width: 200px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;
@@ -180,7 +180,7 @@
 .skeleton-hero-exp-icon {
 	width: 35px;
 	height: 16.33px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;
@@ -190,7 +190,7 @@
 .skeleton-hero-progress-gauge {
 	width: 100%;
 	height: 20px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border: 2px solid var(--color-primary-white);

--- a/src/features/dashboard/components/dashboard-latest-item-section/DashboardLatestItemSection.module.css
+++ b/src/features/dashboard/components/dashboard-latest-item-section/DashboardLatestItemSection.module.css
@@ -37,7 +37,7 @@
 .last-item-guest-user-container,
 .last-item-null-container {
 	display: block grid;
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	background-color: var(--color-primary-brown-dark);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
@@ -45,7 +45,7 @@
 
 .last-item-guest-user-message,
 .last-item-null-message {
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 2px solid var(--color-primary-brown-light);
 	padding: 15px;
 	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
@@ -55,7 +55,7 @@
 	display: block grid;
 	text-decoration: none;
 	background-color: var(--color-primary-brown-dark);
-	border: 2.7mm ridge #b69973;
+	border: 2.7mm ridge var(--color-border-primary);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
 }
@@ -64,7 +64,7 @@
 	display: block grid;
 	grid-template-columns: auto 1fr;
 	gap: 25px;
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 2px solid var(--color-primary-brown-light);
 	padding-block: 15px;
 	padding-inline: 20px;
@@ -130,7 +130,7 @@
 	line-height: var(--leading-tight);
 	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
 	transition: text-shadow 0.15s ease-in-out;
-	border: 2px solid #b69973;
+	border: 2px solid var(--color-border-primary);
 	padding-block: 2px;
 	padding-inline: 8.5px;
 }

--- a/src/features/dashboard/components/dashboard-latest-item-skeleton/DashboardLatestItemSkeleton.module.css
+++ b/src/features/dashboard/components/dashboard-latest-item-skeleton/DashboardLatestItemSkeleton.module.css
@@ -10,7 +10,7 @@
 .skeleton-section-title {
 	width: 200px;
 	height: 28px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;
@@ -41,10 +41,10 @@
 .skeleton-last-item-guest {
 	min-width: 300px;
 	height: 140px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
-	border: 2.7mm ridge #b69973;
+	border: 2.7mm ridge var(--color-border-primary);
 	background-color: var(--color-primary-brown-dark);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
@@ -54,7 +54,7 @@
 .skeleton-item-share {
 	width: 200px;
 	height: 20px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;

--- a/src/features/dashboard/components/dashboard-latest-party-member-section/DashboardLatestPartyMemberSection.module.css
+++ b/src/features/dashboard/components/dashboard-latest-party-member-section/DashboardLatestPartyMemberSection.module.css
@@ -37,7 +37,7 @@
 .party-member-guest-user-container,
 .party-member-null-container {
 	display: block grid;
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	background-color: var(--color-primary-brown-dark);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
@@ -45,7 +45,7 @@
 
 .party-member-guest-user-message,
 .party-member-null-message {
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 2px solid var(--color-primary-brown-light);
 	padding: 15px;
 	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
@@ -55,7 +55,7 @@
 	display: block grid;
 	text-decoration: none;
 	background-color: var(--color-primary-brown-dark);
-	border: 2.7mm ridge #b69973;
+	border: 2.7mm ridge var(--color-border-primary);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
 }
@@ -64,7 +64,7 @@
 	display: block grid;
 	grid-template-columns: auto 1fr;
 	gap: 25px;
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 2px solid var(--color-primary-brown-light);
 	padding-block: 15px;
 	padding-inline: 20px;
@@ -130,7 +130,7 @@
 	line-height: var(--leading-tight);
 	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
 	transition: text-shadow 0.15s ease-in-out;
-	border: 2px solid #b69973;
+	border: 2px solid var(--color-border-primary);
 	padding-block: 2px;
 	padding-inline: 8.5px;
 }

--- a/src/features/dashboard/components/dashboard-latest-party-member-skeleton/DashboardLatestPartyMemberSkeleton.module.css
+++ b/src/features/dashboard/components/dashboard-latest-party-member-skeleton/DashboardLatestPartyMemberSkeleton.module.css
@@ -10,7 +10,7 @@
 .skeleton-section-title {
 	width: 200px;
 	height: 28px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;
@@ -41,10 +41,10 @@
 .skeleton-party-member-guest {
 	min-width: 300px;
 	height: 140px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
-	border: 2.7mm ridge #b69973;
+	border: 2.7mm ridge var(--color-border-primary);
 	background-color: var(--color-primary-brown-dark);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
@@ -54,7 +54,7 @@
 .skeleton-party-share {
 	width: 200px;
 	height: 20px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;

--- a/src/features/dashboard/components/dashboard-platform-stats-section/DashboardPlatformStatsSection.module.css
+++ b/src/features/dashboard/components/dashboard-platform-stats-section/DashboardPlatformStatsSection.module.css
@@ -48,7 +48,7 @@
 	min-width: 200px;
 	height: 135.5px;
 	background-color: var(--color-primary-brown-dark);
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
 }

--- a/src/features/dashboard/components/dashboard-platform-stats-skeleton/DashboardPlatformStatsSkeleton.module.css
+++ b/src/features/dashboard/components/dashboard-platform-stats-skeleton/DashboardPlatformStatsSkeleton.module.css
@@ -2,7 +2,7 @@
 .skeleton-section-title {
 	width: 200px;
 	height: 28px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;
@@ -39,10 +39,10 @@
 .skeleton-platform-card {
 	min-width: 200px;
 	height: 135.5px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	background-color: var(--color-primary-brown-dark);
 }
 
@@ -50,7 +50,7 @@
 .skeleton-platform-share {
 	width: 200px;
 	height: 20px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;

--- a/src/features/explore/components/explore-article-analysis/ExploreArticleAnalysis.module.css
+++ b/src/features/explore/components/explore-article-analysis/ExploreArticleAnalysis.module.css
@@ -33,8 +33,8 @@
 	border-radius: var(--border-radius-small);
 	padding-block: 2.5px;
 	padding-inline: 2.5px;
-	background-color: #5a4734;
-	border: 2.5px solid #b69973;
+	background-color: var(--color-bg-button);
+	border: 2.5px solid var(--color-border-primary);
 	border-radius: var(--border-radius-small);
 
 	&:hover {
@@ -54,7 +54,7 @@
 	display: block grid;
 	place-items: center;
 	width: 100%;
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 1.5px solid var(--color-primary-brown-light);
 	padding-block: 10px 11px;
 	padding-inline: 24px;
@@ -109,7 +109,7 @@
 .explore-results-content {
 	overflow: hidden;
 	background-color: var(--color-primary-brown-dark);
-	border: 4mm ridge #b69973;
+	border: 4mm ridge var(--color-border-primary);
 	padding-block: 3px;
 	padding-inline: 3px;
 }

--- a/src/features/explore/components/explore-page-client/ExplorePageClient.module.css
+++ b/src/features/explore/components/explore-page-client/ExplorePageClient.module.css
@@ -42,8 +42,8 @@
 	border-radius: var(--border-radius-small);
 	padding-block: 2.5px;
 	padding-inline: 2.5px;
-	background-color: #5a4734;
-	border: 2.5px solid #b69973;
+	background-color: var(--color-bg-button);
+	border: 2.5px solid var(--color-border-primary);
 }
 
 .explore-analyze-button:hover .explore-analyze-button-text {
@@ -56,7 +56,7 @@
 	align-items: center;
 	gap: 8px;
 	width: 100%;
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 1.5px solid var(--color-primary-brown-light);
 	padding-block: 10px 11px;
 	padding-inline: 15px;

--- a/src/features/item-detail/components/item-detail-content/ItemDetailContent.module.css
+++ b/src/features/item-detail/components/item-detail-content/ItemDetailContent.module.css
@@ -549,7 +549,7 @@
 	display: block grid;
 	place-items: center;
 	background-color: var(--color-primary-brown-dark);
-	border: 1mm ridge #b69973;
+	border: 1mm ridge var(--color-border-primary);
 	padding-inline: 1.5px;
 	padding-block: 1.5px;
 }
@@ -578,7 +578,7 @@
 	display: block grid;
 	place-items: center;
 	background-color: var(--color-primary-brown-dark);
-	border: 1mm ridge #b69973;
+	border: 1mm ridge var(--color-border-primary);
 	padding-inline: 1.5px;
 	padding-block: 1.5px;
 }

--- a/src/features/item-detail/components/item-detail-skeleton/ItemDetailSkeleton.module.css
+++ b/src/features/item-detail/components/item-detail-skeleton/ItemDetailSkeleton.module.css
@@ -15,7 +15,7 @@
 	display: block grid;
 	place-items: center;
 	background-color: var(--color-primary-brown-dark);
-	border: 5mm ridge #b69973;
+	border: 5mm ridge var(--color-border-primary);
 	padding-block: 2.5px;
 	padding-inline: 2.5px;
 
@@ -39,7 +39,7 @@
 .skeleton-bg {
 	width: 100%;
 	height: 100%;
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 2px solid var(--color-primary-brown-light);
 	display: block grid;
 	place-items: center;
@@ -68,7 +68,7 @@
 	place-items: center;
 	width: 100%;
 	height: 100%;
-	border: 1mm ridge #b69973;
+	border: 1mm ridge var(--color-border-primary);
 	padding-block: 2.5px;
 	padding-inline: 2.5px;
 }
@@ -76,7 +76,7 @@
 .skeleton-image {
 	width: 100%;
 	height: 100%;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 }
@@ -88,7 +88,7 @@
 	place-items: center;
 	padding: 1.5px;
 	background-color: var(--color-primary-brown-dark);
-	border: 1mm ridge #b69973;
+	border: 1mm ridge var(--color-border-primary);
 
 	@media (max-width: 767px) {
 		width: 84px;
@@ -99,7 +99,7 @@
 .skeleton-title {
 	width: 100%;
 	height: 100%;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 }
@@ -111,14 +111,14 @@
 	place-items: center;
 	padding: 1.5px;
 	background-color: var(--color-primary-brown-dark);
-	border: 1mm ridge #b69973;
+	border: 1mm ridge var(--color-border-primary);
 }
 
 .skeleton-description-line {
 	width: 100%;
 	height: 100%;
 	min-height: 80px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 }

--- a/src/features/items/components/item-card-list-client/ItemCardListClient.module.css
+++ b/src/features/items/components/item-card-list-client/ItemCardListClient.module.css
@@ -218,7 +218,7 @@
 
 .item-name-box {
 	background-color: var(--color-primary-brown-dark);
-	border: 1.5mm ridge #b69973;
+	border: 1.5mm ridge var(--color-border-primary);
 	padding-inline: 2px;
 	padding-block: 2px;
 }
@@ -229,7 +229,7 @@
 	line-height: var(--leading-tight);
 	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
 	border: 1px solid var(--color-primary-brown-light);
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	padding-block: 1px 3px;
 	padding-inline: 15px;
 }

--- a/src/features/items/components/item-list-skeleton/ItemListSkeleton.module.css
+++ b/src/features/items/components/item-list-skeleton/ItemListSkeleton.module.css
@@ -34,7 +34,7 @@
 	height: auto;
 	aspect-ratio: 1 / 1;
 	border-radius: 10px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 }
@@ -43,7 +43,7 @@
 	width: 60%;
 	height: 50px;
 	border-radius: 4px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	animation-delay: 0.2s;

--- a/src/features/party-member/components/party-member-detail-content/PartyMemberDetailContent.module.css
+++ b/src/features/party-member/components/party-member-detail-content/PartyMemberDetailContent.module.css
@@ -263,7 +263,7 @@
 	display: block grid;
 	place-items: center;
 	background-color: var(--color-primary-brown-dark);
-	border: 1mm ridge #b69973;
+	border: 1mm ridge var(--color-border-primary);
 	padding-inline: 1.5px;
 	padding-block: 1.5px;
 }
@@ -292,7 +292,7 @@
 	display: block grid;
 	place-items: center;
 	background-color: var(--color-primary-brown-dark);
-	border: 1mm ridge #b69973;
+	border: 1mm ridge var(--color-border-primary);
 	padding-inline: 1.5px;
 	padding-block: 1.5px;
 }

--- a/src/features/party-member/components/party-member-detail-skeleton/PartyMemberDetailSkeleton.module.css
+++ b/src/features/party-member/components/party-member-detail-skeleton/PartyMemberDetailSkeleton.module.css
@@ -15,7 +15,7 @@
 	display: block grid;
 	place-items: center;
 	background-color: var(--color-primary-brown-dark);
-	border: 5mm ridge #b69973;
+	border: 5mm ridge var(--color-border-primary);
 	padding-block: 2.5px;
 	padding-inline: 2.5px;
 
@@ -39,7 +39,7 @@
 .skeleton-bg {
 	width: 100%;
 	height: 100%;
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 2px solid var(--color-primary-brown-light);
 	display: block grid;
 	place-items: center;
@@ -68,7 +68,7 @@
 	place-items: center;
 	width: 100%;
 	height: 100%;
-	border: 1mm ridge #b69973;
+	border: 1mm ridge var(--color-border-primary);
 	padding-block: 2.5px;
 	padding-inline: 2.5px;
 }
@@ -76,7 +76,7 @@
 .skeleton-image {
 	width: 100%;
 	height: 100%;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 }
@@ -88,7 +88,7 @@
 	place-items: center;
 	padding: 1.5px;
 	background-color: var(--color-primary-brown-dark);
-	border: 1mm ridge #b69973;
+	border: 1mm ridge var(--color-border-primary);
 
 	@media (max-width: 767px) {
 		width: 84px;
@@ -99,7 +99,7 @@
 .skeleton-title {
 	width: 100%;
 	height: 100%;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 }
@@ -111,14 +111,14 @@
 	place-items: center;
 	padding: 1.5px;
 	background-color: var(--color-primary-brown-dark);
-	border: 1mm ridge #b69973;
+	border: 1mm ridge var(--color-border-primary);
 }
 
 .skeleton-description-line {
 	width: 100%;
 	height: 100%;
 	min-height: 80px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 }

--- a/src/features/party/components/party-list-skeleton/PartyListSkeleton.module.css
+++ b/src/features/party/components/party-list-skeleton/PartyListSkeleton.module.css
@@ -40,7 +40,7 @@
 	height: auto;
 	aspect-ratio: 1 / 1;
 	border-radius: 10px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 }
@@ -49,7 +49,7 @@
 	width: 60%;
 	height: 50px;
 	border-radius: 4px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	animation-delay: 0.2s;

--- a/src/features/party/components/party-member-card-list-client/PartyMemberCardListClient.module.css
+++ b/src/features/party/components/party-member-card-list-client/PartyMemberCardListClient.module.css
@@ -132,7 +132,7 @@
 
 .party-member-name-box {
 	background-color: var(--color-primary-brown-dark);
-	border: 1.5mm ridge #b69973;
+	border: 1.5mm ridge var(--color-border-primary);
 	padding-inline: 2px;
 	padding-block: 2px;
 }
@@ -143,7 +143,7 @@
 	line-height: var(--leading-tight);
 	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
 	border: 1px solid var(--color-primary-brown-light);
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	padding-block: 1px 3px;
 	padding-inline: 15px;
 }

--- a/src/features/posts/components/post-card/PostCard.module.css
+++ b/src/features/posts/components/post-card/PostCard.module.css
@@ -15,7 +15,7 @@
 	padding-inline: 15px;
 	padding-block: 15px;
 	border: 2px solid var(--color-primary-brown-light);
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	transition: border 0.2s ease-in-out;
 
 	&:hover {
@@ -58,7 +58,7 @@
 	font-weight: var(--font-weight-x-bold);
 	line-height: var(--leading-none);
 	letter-spacing: 0.025em;
-	border: 2px solid #b69973;
+	border: 2px solid var(--color-border-primary);
 	border-radius: var(--matched-radius-inner-size);
 	padding-inline: 8.5px;
 	padding-block: 5.5px 6.5px;

--- a/src/features/posts/components/posts-list/PostsList.module.css
+++ b/src/features/posts/components/posts-list/PostsList.module.css
@@ -21,7 +21,7 @@
 	grid-template-rows: subgrid;
 	grid-row: span 4;
 	background-color: var(--color-primary-brown-dark);
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	border-radius: var(--border-radius-small);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;

--- a/src/features/posts/components/zenn-posts-skeleton/ZennPostsSkeleton.module.css
+++ b/src/features/posts/components/zenn-posts-skeleton/ZennPostsSkeleton.module.css
@@ -22,7 +22,7 @@
 	grid-template-rows: subgrid;
 	grid-row: span 4;
 	background-color: var(--color-primary-brown-dark);
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	border-radius: var(--border-radius-small);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
@@ -37,7 +37,7 @@
 	padding-inline: 15px;
 	padding-block: 15px;
 	border: 2px solid var(--color-primary-brown-light);
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	min-height: 150px; /* CLS prevention */
 }
 
@@ -45,7 +45,7 @@
 .skeleton-title {
 	width: 85%;
 	height: 24px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;
@@ -73,7 +73,7 @@
 .skeleton-category,
 .skeleton-date {
 	height: 28px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;
@@ -98,7 +98,7 @@
 .skeleton-favicon {
 	width: 14px;
 	height: 14px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 2px;
@@ -107,7 +107,7 @@
 .skeleton-platform-text {
 	width: 40px;
 	height: 12px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 2px;

--- a/src/features/strength/components/strength-hero-info-client/StrengthHeroInfoClient.module.css
+++ b/src/features/strength/components/strength-hero-info-client/StrengthHeroInfoClient.module.css
@@ -1,7 +1,7 @@
 /*（左上）勇者のコンテンツ */
 .strength-hero-info {
 	height: 100%;
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	background-color: var(--color-primary-brown-dark);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
@@ -13,7 +13,7 @@
 	grid-template-columns: auto;
 	grid-template-rows: auto 1fr auto;
 	gap: 10px;
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 2px solid var(--color-primary-brown-light);
 	padding-inline: 10px;
 	padding-block: 10px;
@@ -73,7 +73,7 @@
 
 .strength-hero-name-box {
 	background-color: var(--color-primary-brown-dark);
-	border: 1.5mm ridge #b69973;
+	border: 1.5mm ridge var(--color-border-primary);
 	padding-inline: 1.5px;
 	padding-block: 1.5px;
 }
@@ -84,7 +84,7 @@
 	line-height: var(--leading-tight);
 	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
 	border: 1px solid var(--color-primary-brown-light);
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	align-items: center;
 	gap: 5px;
 	padding-block: 2px 3px;
@@ -106,7 +106,7 @@
 .strength-level-display-box {
 	display: block grid;
 	background-color: var(--color-primary-brown-dark);
-	border: 2.5mm ridge #b69973;
+	border: 2.5mm ridge var(--color-border-primary);
 	padding-block: 2.5px;
 	padding-inline: 2.5px;
 }
@@ -121,7 +121,7 @@
 	padding-block: 10px;
 	padding-inline: 10px;
 	border: 2px solid var(--color-primary-brown-light);
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	text-shadow: 2px 2px 0px var(--color-primary-black);
 }
 

--- a/src/features/strength/components/strength-hero-info-skeleton/StrengthHeroInfoSkeleton.module.css
+++ b/src/features/strength/components/strength-hero-info-skeleton/StrengthHeroInfoSkeleton.module.css
@@ -1,7 +1,7 @@
 /* Container - matches strength-hero-info */
 .skeleton-container {
 	height: 100%;
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	background-color: var(--color-primary-brown-dark);
 	border-radius: var(--border-radius-small);
 	padding-inline: 2.5px;
@@ -15,7 +15,7 @@
 	grid-template-columns: auto;
 	grid-template-rows: auto 1fr auto;
 	gap: 10px;
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 2px solid var(--color-primary-brown-light);
 	padding-inline: 10px;
 	padding-block: 10px;
@@ -70,7 +70,7 @@
 .skeleton-icon {
 	width: 110px;
 	height: 110px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;
@@ -80,7 +80,7 @@
 .skeleton-name {
 	width: 140px;
 	height: 28px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: var(--border-radius-small);
@@ -97,7 +97,7 @@
 .skeleton-level-display-box {
 	display: block grid;
 	background-color: var(--color-primary-brown-dark);
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	padding-block: 2px;
 	padding-inline: 2px;
 }
@@ -106,7 +106,7 @@
 .skeleton-level {
 	width: 100px;
 	height: 56px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: var(--border-radius-small);
@@ -130,7 +130,7 @@
 .skeleton-progress-label {
 	width: 150px;
 	height: 16px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;
@@ -139,7 +139,7 @@
 .skeleton-progress-value {
 	width: 60px;
 	height: 20px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;
@@ -155,7 +155,7 @@
 .skeleton-progress-icon {
 	width: 35px;
 	height: 16.33px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;
@@ -164,7 +164,7 @@
 .skeleton-progress-gauge {
 	width: 100%;
 	height: 20px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: var(--border-rounded);

--- a/src/features/strength/components/strength-hero-info/StrengthHeroInfo.module.css
+++ b/src/features/strength/components/strength-hero-info/StrengthHeroInfo.module.css
@@ -1,7 +1,7 @@
 /*（左上）勇者のコンテンツ */
 .strength-hero-info {
 	height: 100%;
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	background-color: var(--color-primary-brown-dark);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
@@ -13,7 +13,7 @@
 	grid-template-columns: auto;
 	grid-template-rows: auto 1fr auto;
 	gap: 10px;
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 2px solid var(--color-primary-brown-light);
 	padding-inline: 10px;
 	padding-block: 10px;

--- a/src/features/strength/components/strength-log-info/StrengthLogInfo.module.css
+++ b/src/features/strength/components/strength-log-info/StrengthLogInfo.module.css
@@ -1,6 +1,6 @@
 .strength-log-info {
 	height: 100%;
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	background-color: var(--color-primary-brown-dark);
 	border-radius: var(--border-radius-small);
 	padding-inline: 2.5px;
@@ -12,7 +12,7 @@
 	display: block grid;
 	grid-template-columns: auto;
 	gap: 20px;
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 2px solid var(--color-primary-brown-light);
 }
 

--- a/src/features/strength/components/strength-title-info-skeleton/StrengthTitleInfoSkeleton.module.css
+++ b/src/features/strength/components/strength-title-info-skeleton/StrengthTitleInfoSkeleton.module.css
@@ -1,6 +1,6 @@
 .skeleton-container {
 	grid-column: span 2;
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	background-color: var(--color-primary-brown-dark);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
@@ -15,7 +15,7 @@
 	display: block grid;
 	grid-template-columns: auto;
 	gap: 20px;
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 2px solid var(--color-primary-brown-light);
 }
 
@@ -58,7 +58,7 @@
 	display: block grid;
 	place-items: center;
 	background-color: var(--color-primary-brown-dark);
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
 }

--- a/src/features/strength/components/strength-title-info/StrengthTitleInfo.module.css
+++ b/src/features/strength/components/strength-title-info/StrengthTitleInfo.module.css
@@ -1,5 +1,5 @@
 .strength-title-info {
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	background-color: var(--color-primary-brown-dark);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
@@ -10,7 +10,7 @@
 	display: block grid;
 	grid-template-columns: auto;
 	gap: 20px;
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 2px solid var(--color-primary-brown-light);
 }
 
@@ -53,7 +53,7 @@
 	display: block grid;
 	place-items: center;
 	background-color: var(--color-primary-brown-dark);
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
 }

--- a/src/features/title/components/title-list-skeleton/TitleListSkeleton.module.css
+++ b/src/features/title/components/title-list-skeleton/TitleListSkeleton.module.css
@@ -20,7 +20,7 @@
 	grid-template-rows: subgrid;
 	grid-row: span 1;
 	background-color: var(--color-primary-brown-dark);
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	padding-inline: 5px;
 	padding-block: 5px;
 	border-radius: var(--border-radius-small);
@@ -44,7 +44,7 @@
 .skeleton-title {
 	width: 70%;
 	height: 22.5px;
-	background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 	border-radius: 4px;

--- a/src/features/title/components/title-list/TitleList.module.css
+++ b/src/features/title/components/title-list/TitleList.module.css
@@ -18,7 +18,7 @@
 	grid-template-rows: subgrid;
 	grid-row: span 1;
 	background-color: var(--color-primary-brown-dark);
-	border: 3mm ridge #b69973;
+	border: 3mm ridge var(--color-border-primary);
 	padding-inline: 2.5px;
 	padding-block: 2.5px;
 }
@@ -29,7 +29,7 @@
 	place-items: center;
 	grid-row: span 1;
 	gap: 15px;
-	background-color: #ae926e;
+	background-color: var(--color-bg-component);
 	border: 2px solid var(--color-primary-brown-light);
 	padding-inline: 15px;
 	padding-block: 25px;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -83,6 +83,17 @@
 		/* zenn */
 		--color-zenn: #3ea8ff;
 
+		/* ボーダー */
+		--color-border-primary: #b69973;
+
+		/* 背景色 */
+		--color-bg-component: #ae926e;
+		--color-bg-button: #5a4734;
+
+		/* スケルトン */
+		--color-skeleton-base: #2a2a2a;
+		--color-skeleton-highlight: #3a3a3a;
+
 		/* 経験値バー関連 */
 		--bg-progress-gauge: #4a4a4a;
 		--color-progress-fill: #d98500;


### PR DESCRIPTION
## Summary

- プロジェクト内で繰り返し使用されているハードコードされたカラー値をCSS変数化
- メンテナンス性の向上

## 追加したCSS変数

| 変数名 | 値 | 用途 | 置換数 |
|--------|-----|------|--------|
| `--color-border-primary` | #b69973 | ボーダーカラー | 58箇所 |
| `--color-bg-component` | #ae926e | コンポーネント背景色 | 29箇所 |
| `--color-bg-button` | #5a4734 | ボタン背景色 | 5箇所 |
| `--color-skeleton-base` | #2a2a2a | スケルトンベース色 | 88箇所 |
| `--color-skeleton-highlight` | #3a3a3a | スケルトンハイライト色 | 44箇所 |

## 変更ファイル

- `globals.css`: CSS変数定義を追加
- 39個のCSSモジュール: ハードコード値を変数に置換

## 関連Issue

Closes #87

## Test plan

- [x] `pnpm build` でビルドが成功することを確認
- [x] `pnpm dev` で各ページの表示確認
- [x] ボーダー、背景色、スケルトンアニメーションが正しく表示されることを目視確認