### PR TITLE
perf(image): ファーストビュー画像にpriority属性を追加 (#89)

### DIFF
--- a/src/components/common/crown/Crown.tsx
+++ b/src/components/common/crown/Crown.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 
 const Crown = () => {
-	return <Image src="/images/crown/crown01.png" alt="crown" width={100} height={100} />;
+	return <Image src="/images/crown/crown01.png" alt="crown" width={100} height={100} priority />;
 };
 
 export default Crown;

--- a/src/features/connection/components/connection-auth-section/ConnectionAuthSection.tsx
+++ b/src/features/connection/components/connection-auth-section/ConnectionAuthSection.tsx
@@ -28,6 +28,7 @@ const ConnectionAuthSection: React.FC<ConnectionAuthSectionProps> = ({
 								width={18}
 								height={18}
 								className={styles["zenn-logo"]}
+								priority
 							/>
 							<span className="grid">Zennとの連携には</span>
 						</span>
@@ -56,6 +57,7 @@ const ConnectionAuthSection: React.FC<ConnectionAuthSectionProps> = ({
 						width={16}
 						height={16}
 						className={styles["zenn-logo-sm"]}
+						priority
 					/>
 					<span>Zennユーザー名</span>
 					<strong className="text-[#ffc630]">(必須)</strong>

--- a/src/features/connection/components/connection-navigation-to-adventure/ConnectionNavigationToAdventure.tsx
+++ b/src/features/connection/components/connection-navigation-to-adventure/ConnectionNavigationToAdventure.tsx
@@ -23,6 +23,7 @@ const ConnectionNavigationToAdventure: React.FC<ConnectionNavigationToAdventureP
 						width={17}
 						height={17}
 						className={styles["adventure-start-link-icon"]}
+						priority
 					/>
 					<span className={styles["adventure-start-link-text"]}>冒険をはじめる</span>
 				</Link>

--- a/src/features/connection/components/connection-zenn-form/ConnectionZennForm.tsx
+++ b/src/features/connection/components/connection-zenn-form/ConnectionZennForm.tsx
@@ -49,6 +49,7 @@ const ConnectionZennForm = memo<ConnectionZennFormProps>(function ConnectionZenn
 					width={16}
 					height={16}
 					className={styles["zenn-logo-sm"]}
+					priority
 				/>
 				<span>Zennユーザー名</span>
 				<strong className="text-[#ffc630]">(必須)</strong>

--- a/src/features/posts/components/post-card/PostCard.tsx
+++ b/src/features/posts/components/post-card/PostCard.tsx
@@ -90,6 +90,7 @@ const PostCard = ({ title, url, category, publishedAt, platformType }: PostCardP
 								width={14}
 								height={14}
 								className={`${styles["favicon"]}`}
+								priority
 							/>
 							<p className={`${styles["post-card__site-name-text"]}`}>{platformInfo.name}</p>
 						</>


### PR DESCRIPTION
## Summary

- ファーストビューに表示される画像に `priority={true}` を付与し、LCP（Largest Contentful Paint）を改善
- 対象コンポーネント:
  - `Crown.tsx` - 複数ページで使用される共有コンポーネント
  - `PostCard.tsx` - 投稿一覧ページのZennファビコン
  - `ConnectionAuthSection.tsx` - 連携ページのZennロゴ (2箇所)
  - `ConnectionZennForm.tsx` - フォーム上部のZennロゴ
  - `ConnectionNavigationToAdventure.tsx` - 連携ページのメインCTA矢印アイコン

## Test plan

- [x] `pnpm build` でビルドが成功することを確認
- [x] Lighthouse でLCPスコアを比較（Before/After）

Closes #89