### PR TITLE
refactor(css): --color-bg-component を --color-bg-panel に変更 (#91)

### DIFF
--- a/src/components/auth/auth-button/AuthButton.module.css
+++ b/src/components/auth/auth-button/AuthButton.module.css
@@ -26,7 +26,7 @@
 	position: relative;
 	display: block flow;
 	width: 100%;
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 1.5px solid var(--color-primary-brown-light);
 	padding-block: 10px 11px;
 	padding-inline: 15px;

--- a/src/features/connection/components/connection-auth-section/ConnectionAuthSection.module.css
+++ b/src/features/connection/components/connection-auth-section/ConnectionAuthSection.module.css
@@ -36,7 +36,7 @@
 .connect-button-content {
 	width: 100%;
 	height: 100%;
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 1.5px solid var(--color-primary-brown-light);
 	place-items: center;
 	padding-block: 5px;

--- a/src/features/connection/components/connection-zenn-form/ConnectionZennForm.module.css
+++ b/src/features/connection/components/connection-zenn-form/ConnectionZennForm.module.css
@@ -19,7 +19,7 @@
 }
 
 .connect-button-content {
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 1.5px solid var(--color-primary-brown-light);
 	place-items: center;
 	padding-block: 5px;

--- a/src/features/connection/components/connection-zenn-info-display/ConnectionZennInfoDisplay.module.css
+++ b/src/features/connection/components/connection-zenn-info-display/ConnectionZennInfoDisplay.module.css
@@ -19,7 +19,7 @@
 	place-items: center;
 	gap: 20px;
 	border: 2px solid var(--color-primary-brown-light);
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	padding-inline: 20px;
 	padding-block: 15px 25px;
 

--- a/src/features/dashboard/components/dashboard-activity-content/DashboardActivityContent.module.css
+++ b/src/features/dashboard/components/dashboard-activity-content/DashboardActivityContent.module.css
@@ -56,7 +56,7 @@
 	width: 100%;
 	display: block grid;
 	color: var(--color-primary-white);
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 2px solid var(--color-primary-brown-light);
 	padding-inline: 15px;
 	padding-block: 12px 10px;

--- a/src/features/dashboard/components/dashboard-activity-skeleton/DashboardActivitySkeleton.module.css
+++ b/src/features/dashboard/components/dashboard-activity-skeleton/DashboardActivitySkeleton.module.css
@@ -57,7 +57,7 @@
 	width: 100%;
 	display: block grid;
 	color: var(--color-primary-white);
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 2px solid var(--color-primary-brown-light);
 	padding-inline: 15px;
 	padding-block: 12px 10px;

--- a/src/features/dashboard/components/dashboard-hero-section/DashboardHeroSection.module.css
+++ b/src/features/dashboard/components/dashboard-hero-section/DashboardHeroSection.module.css
@@ -86,7 +86,7 @@
 	line-height: var(--leading-tight);
 	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
 	border: 1px solid var(--color-primary-brown-light);
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	align-items: center;
 	gap: 5px;
 	padding-block: 2px 3px;
@@ -175,7 +175,7 @@
 }
 
 .hero-info-level-display-box {
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 2px solid var(--color-primary-brown-light);
 	place-content: center;
 	place-items: center;

--- a/src/features/dashboard/components/dashboard-latest-item-section/DashboardLatestItemSection.module.css
+++ b/src/features/dashboard/components/dashboard-latest-item-section/DashboardLatestItemSection.module.css
@@ -45,7 +45,7 @@
 
 .last-item-guest-user-message,
 .last-item-null-message {
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 2px solid var(--color-primary-brown-light);
 	padding: 15px;
 	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
@@ -64,7 +64,7 @@
 	display: block grid;
 	grid-template-columns: auto 1fr;
 	gap: 25px;
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 2px solid var(--color-primary-brown-light);
 	padding-block: 15px;
 	padding-inline: 20px;

--- a/src/features/dashboard/components/dashboard-latest-party-member-section/DashboardLatestPartyMemberSection.module.css
+++ b/src/features/dashboard/components/dashboard-latest-party-member-section/DashboardLatestPartyMemberSection.module.css
@@ -45,7 +45,7 @@
 
 .party-member-guest-user-message,
 .party-member-null-message {
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 2px solid var(--color-primary-brown-light);
 	padding: 15px;
 	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
@@ -64,7 +64,7 @@
 	display: block grid;
 	grid-template-columns: auto 1fr;
 	gap: 25px;
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 2px solid var(--color-primary-brown-light);
 	padding-block: 15px;
 	padding-inline: 20px;

--- a/src/features/explore/components/explore-article-analysis/ExploreArticleAnalysis.module.css
+++ b/src/features/explore/components/explore-article-analysis/ExploreArticleAnalysis.module.css
@@ -54,7 +54,7 @@
 	display: block grid;
 	place-items: center;
 	width: 100%;
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 1.5px solid var(--color-primary-brown-light);
 	padding-block: 10px 11px;
 	padding-inline: 24px;

--- a/src/features/explore/components/explore-page-client/ExplorePageClient.module.css
+++ b/src/features/explore/components/explore-page-client/ExplorePageClient.module.css
@@ -56,7 +56,7 @@
 	align-items: center;
 	gap: 8px;
 	width: 100%;
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 1.5px solid var(--color-primary-brown-light);
 	padding-block: 10px 11px;
 	padding-inline: 15px;

--- a/src/features/item-detail/components/item-detail-skeleton/ItemDetailSkeleton.module.css
+++ b/src/features/item-detail/components/item-detail-skeleton/ItemDetailSkeleton.module.css
@@ -39,7 +39,7 @@
 .skeleton-bg {
 	width: 100%;
 	height: 100%;
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 2px solid var(--color-primary-brown-light);
 	display: block grid;
 	place-items: center;

--- a/src/features/items/components/item-card-list-client/ItemCardListClient.module.css
+++ b/src/features/items/components/item-card-list-client/ItemCardListClient.module.css
@@ -229,7 +229,7 @@
 	line-height: var(--leading-tight);
 	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
 	border: 1px solid var(--color-primary-brown-light);
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	padding-block: 1px 3px;
 	padding-inline: 15px;
 }

--- a/src/features/party-member/components/party-member-detail-skeleton/PartyMemberDetailSkeleton.module.css
+++ b/src/features/party-member/components/party-member-detail-skeleton/PartyMemberDetailSkeleton.module.css
@@ -39,7 +39,7 @@
 .skeleton-bg {
 	width: 100%;
 	height: 100%;
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 2px solid var(--color-primary-brown-light);
 	display: block grid;
 	place-items: center;

--- a/src/features/party/components/party-member-card-list-client/PartyMemberCardListClient.module.css
+++ b/src/features/party/components/party-member-card-list-client/PartyMemberCardListClient.module.css
@@ -143,7 +143,7 @@
 	line-height: var(--leading-tight);
 	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
 	border: 1px solid var(--color-primary-brown-light);
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	padding-block: 1px 3px;
 	padding-inline: 15px;
 }

--- a/src/features/posts/components/post-card/PostCard.module.css
+++ b/src/features/posts/components/post-card/PostCard.module.css
@@ -15,7 +15,7 @@
 	padding-inline: 15px;
 	padding-block: 15px;
 	border: 2px solid var(--color-primary-brown-light);
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	transition: border 0.2s ease-in-out;
 
 	&:hover {

--- a/src/features/posts/components/zenn-posts-skeleton/ZennPostsSkeleton.module.css
+++ b/src/features/posts/components/zenn-posts-skeleton/ZennPostsSkeleton.module.css
@@ -37,7 +37,7 @@
 	padding-inline: 15px;
 	padding-block: 15px;
 	border: 2px solid var(--color-primary-brown-light);
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	min-height: 150px; /* CLS prevention */
 }
 

--- a/src/features/strength/components/strength-hero-info-client/StrengthHeroInfoClient.module.css
+++ b/src/features/strength/components/strength-hero-info-client/StrengthHeroInfoClient.module.css
@@ -13,7 +13,7 @@
 	grid-template-columns: auto;
 	grid-template-rows: auto 1fr auto;
 	gap: 10px;
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 2px solid var(--color-primary-brown-light);
 	padding-inline: 10px;
 	padding-block: 10px;
@@ -84,7 +84,7 @@
 	line-height: var(--leading-tight);
 	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);
 	border: 1px solid var(--color-primary-brown-light);
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	align-items: center;
 	gap: 5px;
 	padding-block: 2px 3px;
@@ -121,7 +121,7 @@
 	padding-block: 10px;
 	padding-inline: 10px;
 	border: 2px solid var(--color-primary-brown-light);
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	text-shadow: 2px 2px 0px var(--color-primary-black);
 }
 

--- a/src/features/strength/components/strength-hero-info-skeleton/StrengthHeroInfoSkeleton.module.css
+++ b/src/features/strength/components/strength-hero-info-skeleton/StrengthHeroInfoSkeleton.module.css
@@ -15,7 +15,7 @@
 	grid-template-columns: auto;
 	grid-template-rows: auto 1fr auto;
 	gap: 10px;
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 2px solid var(--color-primary-brown-light);
 	padding-inline: 10px;
 	padding-block: 10px;

--- a/src/features/strength/components/strength-hero-info/StrengthHeroInfo.module.css
+++ b/src/features/strength/components/strength-hero-info/StrengthHeroInfo.module.css
@@ -13,7 +13,7 @@
 	grid-template-columns: auto;
 	grid-template-rows: auto 1fr auto;
 	gap: 10px;
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 2px solid var(--color-primary-brown-light);
 	padding-inline: 10px;
 	padding-block: 10px;

--- a/src/features/strength/components/strength-log-info/StrengthLogInfo.module.css
+++ b/src/features/strength/components/strength-log-info/StrengthLogInfo.module.css
@@ -12,7 +12,7 @@
 	display: block grid;
 	grid-template-columns: auto;
 	gap: 20px;
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 2px solid var(--color-primary-brown-light);
 }
 

--- a/src/features/strength/components/strength-title-info-skeleton/StrengthTitleInfoSkeleton.module.css
+++ b/src/features/strength/components/strength-title-info-skeleton/StrengthTitleInfoSkeleton.module.css
@@ -15,7 +15,7 @@
 	display: block grid;
 	grid-template-columns: auto;
 	gap: 20px;
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 2px solid var(--color-primary-brown-light);
 }
 

--- a/src/features/strength/components/strength-title-info/StrengthTitleInfo.module.css
+++ b/src/features/strength/components/strength-title-info/StrengthTitleInfo.module.css
@@ -10,7 +10,7 @@
 	display: block grid;
 	grid-template-columns: auto;
 	gap: 20px;
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 2px solid var(--color-primary-brown-light);
 }
 

--- a/src/features/title/components/title-list/TitleList.module.css
+++ b/src/features/title/components/title-list/TitleList.module.css
@@ -29,7 +29,7 @@
 	place-items: center;
 	grid-row: span 1;
 	gap: 15px;
-	background-color: var(--color-bg-component);
+	background-color: var(--color-bg-panel);
 	border: 2px solid var(--color-primary-brown-light);
 	padding-inline: 15px;
 	padding-block: 25px;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -87,7 +87,7 @@
 		--color-border-primary: #b69973;
 
 		/* 背景色 */
-		--color-bg-component: #ae926e;
+		--color-bg-panel: #ae926e;
 		--color-bg-button: #5a4734;
 
 		/* スケルトン */


### PR DESCRIPTION
## Summary

- CSS変数 `--color-bg-component` を `--color-bg-panel` に変更
- 「component」は汎用的すぎて用途が不明確だったため、より適切な命名に修正

## 変更内容

| 変更前 | 変更後 |
|--------|--------|
| `--color-bg-component` | `--color-bg-panel` |

## 影響範囲

- `src/styles/globals.css` (定義)
- 24個のCSS Modules (参照、計30箇所)

## Test plan

- [x] `pnpm build` でビルドが成功することを確認
- [x] `pnpm dev` で各ページの表示確認（色が崩れていないこと）

Closes #91