### PR TITLE
fix(ui): 投稿記事件数のローディングインジケーター表示を修正 (#93)

### DIFF
--- a/src/features/connection/components/connection-zenn-info-display/ConnectionZennInfoDisplay.tsx
+++ b/src/features/connection/components/connection-zenn-info-display/ConnectionZennInfoDisplay.tsx
@@ -48,7 +48,9 @@ const ConnectionZennInfoDisplay: React.FC<ConnectionZennInfoDisplayProps> = ({
 							<span className={styles["article-count-title-text"]}>投稿した記事：</span>
 						</dt>
 						<dd className={styles["article-count-description"]}>
-							{loading ? (
+							{loading ||
+							userInfo.zennArticleCount === undefined ||
+							userInfo.zennArticleCount === null ? (
 								<LoadingIndicator text="" />
 							) : (
 								<>{userInfo.zennArticleCount}件</>


### PR DESCRIPTION
## Summary

- 連携ページの「投稿した記事：〇件」表示で、件数取得中にローディングインジケーターを表示するように修正
- `zennArticleCount` が `undefined` または `null` の場合もローディングインジケーターを表示

## 変更内容

**変更前**:
```tsx
{loading ? (
  <LoadingIndicator text="" />
) : (
  <>{userInfo.zennArticleCount}件</>
)}
```

**変更後**:
```tsx
{loading ||
userInfo.zennArticleCount === undefined ||
userInfo.zennArticleCount === null ? (
  <LoadingIndicator text="" />
) : (
  <>{userInfo.zennArticleCount}件</>
)}
```

## Test plan

- [x] `pnpm build` でビルドが成功することを確認
- [x] 連携ページで件数取得中にローディングインジケーターが表示されることを確認

Closes #93