### PR TITLE
refactor: インラインPrismaクエリをgetUser()に統一

### DIFF
--- a/src/features/item-detail/components/item-detail-card/ItemDetailCard.tsx
+++ b/src/features/item-detail/components/item-detail-card/ItemDetailCard.tsx
@@ -1,7 +1,5 @@
-import { connection } from "next/server";
-import { auth } from "@clerk/nextjs/server";
-import { prisma } from "@/lib/prisma";
 import { getZennArticles } from "@/features/zenn/_lib/fetcher";
+import { getUser } from "@/features/user/_lib/fetcher";
 import {
 	isAcquiredByHeroLevel,
 	heroLevelAndItemRelation,
@@ -23,39 +21,23 @@ interface ItemDetailCardProps {
  * アイテム詳細データを取得して表示するServer Component
  *
  * データフェッチ:
- * - connection() + auth() + prisma: ユーザー認証とDB取得（動的）
+ * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
  * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
  */
 const ItemDetailCard = async ({ itemId }: ItemDetailCardProps) => {
-	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
-	await connection();
-
 	try {
-		// 認証情報を取得
-		const { userId } = await auth();
+		// ユーザー情報を取得（Request Memoization + use cache）
+		const user = await getUser();
 
 		// ゲストユーザーの判定
-		let zennUsername = "aoyamadev"; // デフォルト値
-		let isGuestUser = true;
+		const zennUsername = user?.zennUsername || "aoyamadev";
+		const isGuestUser = !user?.zennUsername;
 		let currentLevel = 1;
 
-		if (userId) {
-			// 認証済みユーザーの場合、DBからzennUsernameを取得
-			const user = await prisma.user.findUnique({
-				where: { clerkId: userId },
-				select: {
-					zennUsername: true,
-				},
-			});
-
-			if (user?.zennUsername) {
-				zennUsername = user.zennUsername;
-				isGuestUser = false;
-
-				// Zenn記事を取得してレベルを計算
-				const articles = await getZennArticles(zennUsername, { fetchAll: true });
-				currentLevel = articles.length;
-			}
+		if (user?.zennUsername) {
+			// Zenn記事を取得してレベルを計算
+			const articles = await getZennArticles(zennUsername, { fetchAll: true });
+			currentLevel = articles.length;
 		}
 
 		// アイテムの入手状態を判定

--- a/src/features/items/components/item-card-list/ItemCardList.tsx
+++ b/src/features/items/components/item-card-list/ItemCardList.tsx
@@ -1,7 +1,5 @@
-import { connection } from "next/server";
-import { auth } from "@clerk/nextjs/server";
-import { prisma } from "@/lib/prisma";
 import { getZennArticles } from "@/features/zenn/_lib/fetcher";
+import { getUser } from "@/features/user/_lib/fetcher";
 import { updateItemsByLevel } from "@/features/items/data/itemsData";
 import * as Items from "@/features/items/components";
 import styles from "./ItemCardList.module.css";
@@ -12,38 +10,17 @@ import styles from "./ItemCardList.module.css";
  * アイテム一覧を取得して表示するServer Component
  *
  * データフェッチ:
- * - connection() + auth() + prisma: ユーザー認証とDB取得（動的）
+ * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
  * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
- *
- * 注意: getUser()を使うとキャッシュの問題でユーザー間でデータが混在する
- * 可能性があるため、認証関連は直接呼び出しを維持
  */
 const ItemCardList = async () => {
-	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
-	await connection();
-
 	try {
-		// 認証情報を取得
-		const { userId } = await auth();
+		// ユーザー情報を取得（Request Memoization + use cache）
+		const user = await getUser();
 
 		// ゲストユーザーの判定
-		let zennUsername = "aoyamadev"; // デフォルト値
-		let isGuestUser = true;
-
-		if (userId) {
-			// 認証済みユーザーの場合、DBからzennUsernameを取得
-			const user = await prisma.user.findUnique({
-				where: { clerkId: userId },
-				select: {
-					zennUsername: true,
-				},
-			});
-
-			if (user?.zennUsername) {
-				zennUsername = user.zennUsername;
-				isGuestUser = false;
-			}
-		}
+		const zennUsername = user?.zennUsername || "aoyamadev";
+		const isGuestUser = !user?.zennUsername;
 
 		// Zenn記事を取得（use cache + Request Memoization）
 		const articles = await getZennArticles(zennUsername, { fetchAll: true });

--- a/src/features/logs/components/logs-list/LogsListWrapper.tsx
+++ b/src/features/logs/components/logs-list/LogsListWrapper.tsx
@@ -1,7 +1,5 @@
-import { connection } from "next/server";
-import { auth } from "@clerk/nextjs/server";
-import { prisma } from "@/lib/prisma";
 import { getZennArticles } from "@/features/zenn/_lib/fetcher";
+import { getUser } from "@/features/user/_lib/fetcher";
 import { getAdventureLogs, syncAdventureLogs } from "@/features/logs/services/logService";
 import LogsList from "./LogsList";
 
@@ -11,31 +9,16 @@ import LogsList from "./LogsList";
  * 冒険ログを同期・取得してLogsListに渡す
  *
  * データフェッチ:
- * - connection() + auth(): ユーザー認証（動的）
- * - prisma: DBからユーザー情報取得
+ * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
  * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
  * - syncAdventureLogs(): ログ同期
  * - getAdventureLogs(): DBからログ取得
- *
- * 注意: connection()を呼ばないとキャッシュされ、ユーザー間でデータが混在する
  */
 const LogsListWrapper = async () => {
-	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
-	await connection();
+	// ユーザー情報を取得（Request Memoization + use cache）
+	const user = await getUser();
 
-	const { userId } = await auth();
-
-	if (!userId) {
-		return <LogsList logs={[]} />;
-	}
-
-	// ユーザー情報を取得
-	const user = await prisma.user.findUnique({
-		where: { clerkId: userId },
-		select: { id: true, zennUsername: true },
-	});
-
-	// Zenn未連携の場合は空のログを表示
+	// 未ログインまたはZenn未連携の場合は空のログを表示
 	if (!user?.zennUsername) {
 		return <LogsList logs={[]} />;
 	}
@@ -45,7 +28,7 @@ const LogsListWrapper = async () => {
 	await syncAdventureLogs(user.id, articles);
 
 	// 同期後のログを取得して表示
-	const logs = await getAdventureLogs(userId);
+	const logs = await getAdventureLogs(user.clerkId);
 
 	return <LogsList logs={logs} />;
 };

--- a/src/features/party-member/components/party-member-detail-card/PartyMemberDetailCard.tsx
+++ b/src/features/party-member/components/party-member-detail-card/PartyMemberDetailCard.tsx
@@ -1,7 +1,5 @@
-import { connection } from "next/server";
-import { auth } from "@clerk/nextjs/server";
-import { prisma } from "@/lib/prisma";
 import { getZennArticles } from "@/features/zenn/_lib/fetcher";
+import { getUser } from "@/features/user/_lib/fetcher";
 import {
 	isAcquiredByHeroLevel,
 	heroLevelAndMemberRelation,
@@ -23,39 +21,23 @@ interface PartyMemberDetailCardProps {
  * なかま詳細データを取得して表示するServer Component
  *
  * データフェッチ:
- * - connection() + auth() + prisma: ユーザー認証とDB取得（動的）
+ * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
  * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
  */
 const PartyMemberDetailCard = async ({ partyId }: PartyMemberDetailCardProps) => {
-	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
-	await connection();
-
 	try {
-		// 認証情報を取得
-		const { userId } = await auth();
+		// ユーザー情報を取得（Request Memoization + use cache）
+		const user = await getUser();
 
 		// ゲストユーザーの判定
-		let zennUsername = "aoyamadev"; // デフォルト値
-		let isGuestUser = true;
+		const zennUsername = user?.zennUsername || "aoyamadev";
+		const isGuestUser = !user?.zennUsername;
 		let currentLevel = 1;
 
-		if (userId) {
-			// 認証済みユーザーの場合、DBからzennUsernameを取得
-			const user = await prisma.user.findUnique({
-				where: { clerkId: userId },
-				select: {
-					zennUsername: true,
-				},
-			});
-
-			if (user?.zennUsername) {
-				zennUsername = user.zennUsername;
-				isGuestUser = false;
-
-				// Zenn記事を取得してレベルを計算
-				const articles = await getZennArticles(zennUsername, { fetchAll: true });
-				currentLevel = articles.length;
-			}
+		if (user?.zennUsername) {
+			// Zenn記事を取得してレベルを計算
+			const articles = await getZennArticles(zennUsername, { fetchAll: true });
+			currentLevel = articles.length;
 		}
 
 		// 仲間の入手状態を判定

--- a/src/features/party/components/party-member-card-list/PartyMemberCardList.tsx
+++ b/src/features/party/components/party-member-card-list/PartyMemberCardList.tsx
@@ -1,7 +1,5 @@
-import { connection } from "next/server";
-import { auth } from "@clerk/nextjs/server";
-import { prisma } from "@/lib/prisma";
 import { getZennArticles } from "@/features/zenn/_lib/fetcher";
+import { getUser } from "@/features/user/_lib/fetcher";
 import { updatePartyMembersByLevel } from "@/features/party/data/partyMemberData";
 import * as Party from "@/features/party/components";
 import styles from "./PartyMemberCardList.module.css";
@@ -12,38 +10,17 @@ import styles from "./PartyMemberCardList.module.css";
  * パーティメンバー一覧を取得して表示するServer Component
  *
  * データフェッチ:
- * - connection() + auth() + prisma: ユーザー認証とDB取得（動的）
+ * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
  * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
- *
- * 注意: getUser()を使うとキャッシュの問題でユーザー間でデータが混在する
- * 可能性があるため、認証関連は直接呼び出しを維持
  */
 const PartyMemberCardList = async () => {
-	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
-	await connection();
-
 	try {
-		// 認証情報を取得
-		const { userId } = await auth();
+		// ユーザー情報を取得（Request Memoization + use cache）
+		const user = await getUser();
 
 		// ゲストユーザーの判定
-		let zennUsername = "aoyamadev"; // デフォルト値
-		let isGuestUser = true;
-
-		if (userId) {
-			// 認証済みユーザーの場合、DBからzennUsernameを取得
-			const user = await prisma.user.findUnique({
-				where: { clerkId: userId },
-				select: {
-					zennUsername: true,
-				},
-			});
-
-			if (user?.zennUsername) {
-				zennUsername = user.zennUsername;
-				isGuestUser = false;
-			}
-		}
+		const zennUsername = user?.zennUsername || "aoyamadev";
+		const isGuestUser = !user?.zennUsername;
 
 		// Zenn記事を取得（use cache + Request Memoization）
 		const articles = await getZennArticles(zennUsername, { fetchAll: true });

--- a/src/features/posts/components/posts-list-with-data/PostsListWithData.tsx
+++ b/src/features/posts/components/posts-list-with-data/PostsListWithData.tsx
@@ -1,7 +1,5 @@
-import { connection } from "next/server";
-import { auth } from "@clerk/nextjs/server";
-import { prisma } from "@/lib/prisma";
 import { getZennArticles } from "@/features/zenn/_lib/fetcher";
+import { getUser } from "@/features/user/_lib/fetcher";
 import { PlatformType } from "@/features/posts/types";
 import * as Posts from "@/features/posts/components";
 import styles from "./PostsListWithData.module.css";
@@ -12,36 +10,16 @@ import styles from "./PostsListWithData.module.css";
  * Zenn記事一覧を取得して表示するServer Component
  *
  * データフェッチ:
- * - connection() + auth() + prisma: ユーザー認証とDB取得（動的）
+ * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
  * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
- *
- * 注意: getUser()を使うとキャッシュの問題でユーザー間でデータが混在する
- * 可能性があるため、認証関連は直接呼び出しを維持
  */
 const PostsListWithData = async () => {
-	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
-	await connection();
-
 	try {
-		// 認証情報を取得
-		const { userId } = await auth();
+		// ユーザー情報を取得（Request Memoization + use cache）
+		const user = await getUser();
 
 		// ゲストユーザーの判定
-		let zennUsername = "aoyamadev"; // デフォルト値
-
-		if (userId) {
-			// 認証済みユーザーの場合、DBからzennUsernameを取得
-			const user = await prisma.user.findUnique({
-				where: { clerkId: userId },
-				select: {
-					zennUsername: true,
-				},
-			});
-
-			if (user?.zennUsername) {
-				zennUsername = user.zennUsername;
-			}
-		}
+		const zennUsername = user?.zennUsername || "aoyamadev";
 
 		// Zenn記事を取得（全件取得）- use cache + Request Memoization
 		const articles = await getZennArticles(zennUsername, { fetchAll: true });

--- a/src/features/strength/components/strength-hero-info/StrengthHeroInfo.tsx
+++ b/src/features/strength/components/strength-hero-info/StrengthHeroInfo.tsx
@@ -1,7 +1,5 @@
-import { connection } from "next/server";
-import { auth } from "@clerk/nextjs/server";
-import { prisma } from "@/lib/prisma";
 import { getZennArticles } from "@/features/zenn/_lib/fetcher";
+import { getUser } from "@/features/user/_lib/fetcher";
 import { strengthHeroData } from "@/features/strength/data/strengthHeroData";
 import * as Strength from "@/features/strength/components";
 import styles from "./StrengthHeroInfo.module.css";
@@ -13,36 +11,16 @@ import styles from "./StrengthHeroInfo.module.css";
  * ItemCardList/PartyMemberCardListと同じパターンで2層分離
  *
  * データフェッチ:
- * - connection() + auth() + prisma: ユーザー認証とDB取得（動的）
+ * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
  * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
- *
- * 注意: getUser()を使うとキャッシュの問題でユーザー間でデータが混在する
- * 可能性があるため、認証関連は直接呼び出しを維持
  */
 const StrengthHeroInfo = async () => {
-	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
-	await connection();
-
 	try {
-		// 認証情報を取得
-		const { userId } = await auth();
+		// ユーザー情報を取得（Request Memoization + use cache）
+		const user = await getUser();
 
 		// ゲストユーザーの判定
-		let zennUsername = "aoyamadev"; // デフォルト値
-
-		if (userId) {
-			// 認証済みユーザーの場合、DBからzennUsernameを取得
-			const user = await prisma.user.findUnique({
-				where: { clerkId: userId },
-				select: {
-					zennUsername: true,
-				},
-			});
-
-			if (user?.zennUsername) {
-				zennUsername = user.zennUsername;
-			}
-		}
+		const zennUsername = user?.zennUsername || "aoyamadev";
 
 		// Zenn記事数を取得（全件取得）
 		const articles = await getZennArticles(zennUsername, { fetchAll: true });

--- a/src/features/strength/components/strength-log-info/StrengthLogInfoWrapper.tsx
+++ b/src/features/strength/components/strength-log-info/StrengthLogInfoWrapper.tsx
@@ -1,7 +1,5 @@
-import { connection } from "next/server";
-import { auth } from "@clerk/nextjs/server";
-import { prisma } from "@/lib/prisma";
 import { getZennArticles } from "@/features/zenn/_lib/fetcher";
+import { getUser } from "@/features/user/_lib/fetcher";
 import { getAdventureLogs, syncAdventureLogs } from "@/features/logs/services/logService";
 import StrengthLogInfo from "./StrengthLogInfo";
 
@@ -11,31 +9,16 @@ import StrengthLogInfo from "./StrengthLogInfo";
  * 冒険ログを同期・取得してStrengthLogInfoに渡す
  *
  * データフェッチ:
- * - connection() + auth(): ユーザー認証（動的）
- * - prisma: DBからユーザー情報取得
+ * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
  * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
  * - syncAdventureLogs(): ログ同期
  * - getAdventureLogs(): DBからログ取得
- *
- * 注意: connection()を呼ばないとキャッシュされ、ユーザー間でデータが混在する
  */
 const StrengthLogInfoWrapper = async () => {
-	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
-	await connection();
+	// ユーザー情報を取得（Request Memoization + use cache）
+	const user = await getUser();
 
-	const { userId } = await auth();
-
-	if (!userId) {
-		return <StrengthLogInfo logs={[]} />;
-	}
-
-	// ユーザー情報を取得
-	const user = await prisma.user.findUnique({
-		where: { clerkId: userId },
-		select: { id: true, zennUsername: true },
-	});
-
-	// Zenn未連携の場合は空のログを表示
+	// 未ログインまたはZenn未連携の場合は空のログを表示
 	if (!user?.zennUsername) {
 		return <StrengthLogInfo logs={[]} />;
 	}
@@ -45,7 +28,7 @@ const StrengthLogInfoWrapper = async () => {
 	await syncAdventureLogs(user.id, articles);
 
 	// 同期後のログを取得して表示
-	const logs = await getAdventureLogs(userId);
+	const logs = await getAdventureLogs(user.clerkId);
 
 	return <StrengthLogInfo logs={logs} />;
 };

--- a/src/features/strength/components/strength-title-info/StrengthTitleInfo.tsx
+++ b/src/features/strength/components/strength-title-info/StrengthTitleInfo.tsx
@@ -1,7 +1,5 @@
-import { connection } from "next/server";
-import { auth } from "@clerk/nextjs/server";
-import { prisma } from "@/lib/prisma";
 import { getZennArticles } from "@/features/zenn/_lib/fetcher";
+import { getUser } from "@/features/user/_lib/fetcher";
 import StrengthTitleInfoClient from "./StrengthTitleInfoClient";
 import styles from "./StrengthTitleInfo.module.css";
 
@@ -12,43 +10,18 @@ import styles from "./StrengthTitleInfo.module.css";
  * StrengthHeroInfoと同じパターンで2層分離
  *
  * データフェッチ:
- * - connection() + auth() + prisma: ユーザー認証とDB取得（動的）
+ * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
  * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
- *
- * 注意: getUser()を使うとキャッシュの問題でユーザー間でデータが混在する
- * 可能性があるため、認証関連は直接呼び出しを維持
  */
 const StrengthTitleInfo = async () => {
-	// Dynamic Renderingを強制（cacheComponents有効時のプリレンダリング対策）
-	await connection();
-
 	try {
-		// 認証情報を取得
-		const { userId } = await auth();
+		// ユーザー情報を取得（Request Memoization + use cache）
+		const user = await getUser();
 
 		// ゲストユーザーの判定
-		let zennUsername: string | null = null;
-		let isGuestUser = true;
-
-		if (userId) {
-			// 認証済みユーザーの場合、DBからzennUsernameを取得
-			const user = await prisma.user.findUnique({
-				where: { clerkId: userId },
-				select: {
-					zennUsername: true,
-				},
-			});
-
-			if (user?.zennUsername) {
-				zennUsername = user.zennUsername;
-				isGuestUser = false;
-			}
-		}
-
-		// Zenn記事数を取得（全件取得）
-		// ゲストユーザーは@aoyamadevのデータを使用
-		const username = zennUsername || "aoyamadev";
-		const articles = await getZennArticles(username, { fetchAll: true });
+		const zennUsername = user?.zennUsername || "aoyamadev";
+		const isGuestUser = !user?.zennUsername;
+		const articles = await getZennArticles(zennUsername, { fetchAll: true });
 		const heroLevel = Math.max(articles.length, 1); // 最低レベル1
 
 		// Client Componentにデータを渡す


### PR DESCRIPTION
## Summary

9つのServer Componentsで重複していたインラインPrismaクエリを、データフェッチ層の `getUser()` に統一。

### Before (各ファイルで重複)
```typescript
const { userId } = await auth();
const user = await prisma.user.findUnique({
  where: { clerkId: userId },
  select: { zennUsername: true },
});
```

### After (getUser()を使用)
```typescript
import { getUser } from "@/features/user/_lib/fetcher";
const user = await getUser();
```

## 変更内容

- **61行追加 / 248行削除** = 約4分の1に圧縮
- 9ファイルのServer Componentsを修正

### 対象ファイル
1. `ItemCardList.tsx`
2. `PartyMemberCardList.tsx`
3. `PostsListWithData.tsx`
4. `StrengthHeroInfo.tsx`
5. `StrengthTitleInfo.tsx`
6. `StrengthLogInfoWrapper.tsx`
7. `PartyMemberDetailCard.tsx`
8. `ItemDetailCard.tsx`
9. `LogsListWrapper.tsx`

## メリット

- **コード重複排除**: 同じクエリが1箇所に集約
- **Request Memoization確実化**: 同一関数を使用することでメモ化が保証される
- **保守性向上**: クエリ変更時に1箇所の修正で済む

## Test plan

- [x] `pnpm build` が成功することを確認
- [x] プリレンダリング時の警告は既存と同様（try/catchでハンドリング済み）

Closes #79