### PR TITLE
refactor: DRY原則違反の解消 (#106)

### DIFF
--- a/src/consts/zenn.ts
+++ b/src/consts/zenn.ts
@@ -1,0 +1,25 @@
+import { PlatformType } from "@/features/posts/types";
+
+/**
+ * Zenn関連の定数
+ *
+ * PostCard と DashboardActivityContent で共通使用
+ */
+
+/**
+ * プラットフォーム情報
+ */
+export const PLATFORM_INFO: Record<PlatformType, { name: string; favicon: string }> = {
+	zenn: {
+		name: "Zenn",
+		favicon: "https://zenn.dev/images/logo-transparent.png",
+	},
+};
+
+/**
+ * カテゴリー表示用のマッピング
+ */
+export const CATEGORY_DISPLAY: Record<string, string> = {
+	tech: "TECH",
+	idea: "IDEA",
+};

--- a/src/features/dashboard/components/dashboard-activity-content/DashboardActivityContent.tsx
+++ b/src/features/dashboard/components/dashboard-activity-content/DashboardActivityContent.tsx
@@ -5,20 +5,8 @@ import Link from "next/link";
 import Image from "next/image";
 import { PostData } from "@/features/posts/types";
 import { useClickSound } from "@/components/common/audio/click-sound/ClickSound";
-
-// カテゴリー表示用のマッピング
-const CATEGORY_DISPLAY = {
-	tech: "TECH",
-	idea: "IDEA",
-};
-
-// プラットフォーム情報
-const PLATFORM_INFO = {
-	zenn: {
-		name: "Zenn",
-		favicon: "https://zenn.dev/images/logo-transparent.png",
-	},
-};
+import { formatDateShort } from "@/utils/formatDate";
+import { PLATFORM_INFO, CATEGORY_DISPLAY } from "@/consts/zenn";
 
 type DashboardActivityContentProps = {
 	articles: PostData[];
@@ -30,24 +18,6 @@ const DashboardActivityContent = ({ articles }: DashboardActivityContentProps) =
 		volume: 0.5,
 		delay: 190,
 	});
-
-	// 日付を表示用にフォーマットする
-	const formatDate = (date: string | Date | undefined): string => {
-		if (!date) return "";
-		if (typeof date === "string") {
-			const dateObj = new Date(date);
-			return dateObj.toLocaleDateString("ja-JP", {
-				year: "numeric",
-				month: "numeric",
-				day: "numeric",
-			});
-		}
-		return date.toLocaleDateString("ja-JP", {
-			year: "numeric",
-			month: "numeric",
-			day: "numeric",
-		});
-	};
 
 	return (
 		<section className={`${styles["recent-activity-section"]}`}>
@@ -91,7 +61,7 @@ const DashboardActivityContent = ({ articles }: DashboardActivityContentProps) =
 
 										<div className={`${styles["recent-activity-item-date-container"]}`}>
 											<span className={`${styles["recent-activity-item-date"]}`}>
-												{formatDate(article.publishedAt || article.date)}
+												{formatDateShort(article.publishedAt || article.date)}
 											</span>
 										</div>
 									</div>

--- a/src/features/item-detail/components/item-detail-card/ItemDetailCard.tsx
+++ b/src/features/item-detail/components/item-detail-card/ItemDetailCard.tsx
@@ -1,5 +1,4 @@
-import { getZennArticles } from "@/features/zenn/_lib/fetcher";
-import { getUser } from "@/features/user/_lib/fetcher";
+import { getUserWithArticles } from "@/features/user/_lib/fetcher";
 import {
 	isAcquiredByHeroLevel,
 	heroLevelAndItemRelation,
@@ -17,19 +16,8 @@ interface ItemDetailCardProps {
 
 const ItemDetailCard = async ({ itemId }: ItemDetailCardProps) => {
 	try {
-		// ユーザー情報を取得（Request Memoization + use cache）
-		const user = await getUser();
-
-		// ゲストユーザーの判定
-		const zennUsername = user?.zennUsername || "aoyamadev";
-		const isGuestUser = !user?.zennUsername;
-		let currentLevel = 1;
-
-		if (user?.zennUsername) {
-			// Zenn記事を取得してレベルを計算
-			const articles = await getZennArticles(zennUsername, { fetchAll: true });
-			currentLevel = articles.length;
-		}
+		const { articleCount, isGuestUser } = await getUserWithArticles();
+		const currentLevel = isGuestUser ? 1 : articleCount;
 
 		// アイテムの入手状態を判定
 		const isAcquired = !isGuestUser && isAcquiredByHeroLevel(itemId, currentLevel);

--- a/src/features/items/components/item-card-list/ItemCardList.tsx
+++ b/src/features/items/components/item-card-list/ItemCardList.tsx
@@ -1,5 +1,4 @@
-import { getZennArticles } from "@/features/zenn/_lib/fetcher";
-import { getUser } from "@/features/user/_lib/fetcher";
+import { getUserWithArticles } from "@/features/user/_lib/fetcher";
 import { updateItemsByLevel } from "@/features/items/data/itemsData";
 import * as Items from "@/features/items/components";
 import styles from "./ItemCardList.module.css";
@@ -8,28 +7,11 @@ import styles from "./ItemCardList.module.css";
  * ItemCardList (Server Component)
  *
  * アイテム一覧を取得して表示するServer Component
- *
- * データフェッチ:
- * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
- * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
  */
 const ItemCardList = async () => {
 	try {
-		// ユーザー情報を取得（Request Memoization + use cache）
-		const user = await getUser();
-
-		// ゲストユーザーの判定
-		const zennUsername = user?.zennUsername || "aoyamadev";
-		const isGuestUser = !user?.zennUsername;
-
-		// Zenn記事を取得（use cache + Request Memoization）
-		const articles = await getZennArticles(zennUsername, { fetchAll: true });
-		const articleCount = articles.length;
-
-		// アイテムデータを更新
+		const { articleCount, isGuestUser } = await getUserWithArticles();
 		const items = updateItemsByLevel(articleCount);
-
-		// Client Componentにデータを渡す
 		return <Items.ItemCardListClient items={items} isGuestUser={isGuestUser} />;
 	} catch (error) {
 		console.error("アイテムデータ取得エラー:", error);

--- a/src/features/logs/components/logs-list-wrapper/LogsListWrapper.tsx
+++ b/src/features/logs/components/logs-list-wrapper/LogsListWrapper.tsx
@@ -1,35 +1,13 @@
-import { getZennArticles } from "@/features/zenn/_lib/fetcher";
-import { getUser } from "@/features/user/_lib/fetcher";
-import { getAdventureLogs, syncAdventureLogs } from "@/features/logs/services/logService";
+import { getAdventureLogsWithSync } from "@/features/logs/services/logService";
 import * as Logs from "@/features/logs/components";
 
 /**
  * LogsListWrapper (Server Component)
  *
  * 冒険ログを同期・取得してLogsListに渡す
- *
- * データフェッチ:
- * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
- * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
- * - syncAdventureLogs(): ログ同期
- * - getAdventureLogs(): DBからログ取得
  */
 const LogsListWrapper = async () => {
-	// ユーザー情報を取得（Request Memoization + use cache）
-	const user = await getUser();
-
-	// 未ログインまたはZenn未連携の場合は空のログを表示
-	if (!user?.zennUsername) {
-		return <Logs.LogsList logs={[]} />;
-	}
-
-	// Zenn記事を取得してログを同期
-	const articles = await getZennArticles(user.zennUsername, { fetchAll: true });
-	await syncAdventureLogs(user.id, articles);
-
-	// 同期後のログを取得して表示
-	const logs = await getAdventureLogs(user.clerkId);
-
+	const logs = await getAdventureLogsWithSync();
 	return <Logs.LogsList logs={logs} />;
 };
 

--- a/src/features/logs/services/logService.ts
+++ b/src/features/logs/services/logService.ts
@@ -7,6 +7,9 @@ import {
 	customMemberNames,
 } from "@/features/party/data/partyMemberData";
 import { titleNameData } from "@/shared/data/titleNameDate";
+import { getUser } from "@/features/user/_lib/fetcher";
+import { getZennArticles } from "@/features/zenn/_lib/fetcher";
+import { formatDateWithTime } from "@/utils/formatDate";
 
 interface Article {
 	id: number | string;
@@ -142,20 +145,6 @@ export interface FormattedLog {
 	formattedDate: string;
 }
 
-/**
- * 日付をフォーマットする関数
- */
-const formatDate = (date: Date): string => {
-	return `${date.getFullYear()}/${(date.getMonth() + 1)
-		.toString()
-		.padStart(2, "0")}/${date.getDate().toString().padStart(2, "0")} ${date
-		.getHours()
-		.toString()
-		.padStart(2, "0")}:${date.getMinutes().toString().padStart(2, "0")}:${date
-		.getSeconds()
-		.toString()
-		.padStart(2, "0")}`;
-};
 
 /**
  * サーバーサイドでAdventureLogを取得する関数
@@ -185,6 +174,31 @@ export const getAdventureLogs = async (clerkId: string): Promise<FormattedLog[]>
 		type: log.type,
 		content: log.content,
 		occurredAt: log.occurredAt,
-		formattedDate: formatDate(log.occurredAt),
+		formattedDate: formatDateWithTime(log.occurredAt),
 	}));
+};
+
+/**
+ * 冒険ログを同期・取得する共通ユーティリティ関数
+ *
+ * LogsListWrapper と StrengthLogInfoWrapper で共通して使用される
+ * データフェッチロジックを抽象化
+ *
+ * @returns 同期済みの冒険ログ配列（未ログインまたはZenn未連携の場合は空配列）
+ */
+export const getAdventureLogsWithSync = async (): Promise<FormattedLog[]> => {
+	// ユーザー情報を取得（Request Memoization + use cache）
+	const user = await getUser();
+
+	// 未ログインまたはZenn未連携の場合は空配列を返す
+	if (!user?.zennUsername) {
+		return [];
+	}
+
+	// Zenn記事を取得してログを同期
+	const articles = await getZennArticles(user.zennUsername, { fetchAll: true });
+	await syncAdventureLogs(user.id, articles);
+
+	// 同期後のログを取得して返す
+	return await getAdventureLogs(user.clerkId);
 };

--- a/src/features/party-member/components/party-member-detail-card/PartyMemberDetailCard.tsx
+++ b/src/features/party-member/components/party-member-detail-card/PartyMemberDetailCard.tsx
@@ -1,5 +1,4 @@
-import { getZennArticles } from "@/features/zenn/_lib/fetcher";
-import { getUser } from "@/features/user/_lib/fetcher";
+import { getUserWithArticles } from "@/features/user/_lib/fetcher";
 import {
 	isAcquiredByHeroLevel,
 	heroLevelAndMemberRelation,
@@ -19,26 +18,11 @@ interface PartyMemberDetailCardProps {
  * PartyMemberDetailCard (Server Component)
  *
  * なかま詳細データを取得して表示するServer Component
- *
- * データフェッチ:
- * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
- * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
  */
 const PartyMemberDetailCard = async ({ partyId }: PartyMemberDetailCardProps) => {
 	try {
-		// ユーザー情報を取得（Request Memoization + use cache）
-		const user = await getUser();
-
-		// ゲストユーザーの判定
-		const zennUsername = user?.zennUsername || "aoyamadev";
-		const isGuestUser = !user?.zennUsername;
-		let currentLevel = 1;
-
-		if (user?.zennUsername) {
-			// Zenn記事を取得してレベルを計算
-			const articles = await getZennArticles(zennUsername, { fetchAll: true });
-			currentLevel = articles.length;
-		}
+		const { articleCount, isGuestUser } = await getUserWithArticles();
+		const currentLevel = isGuestUser ? 1 : articleCount;
 
 		// 仲間の入手状態を判定
 		const isAcquired = !isGuestUser && isAcquiredByHeroLevel(partyId, currentLevel);

--- a/src/features/party/components/party-member-card-list/PartyMemberCardList.tsx
+++ b/src/features/party/components/party-member-card-list/PartyMemberCardList.tsx
@@ -1,5 +1,4 @@
-import { getZennArticles } from "@/features/zenn/_lib/fetcher";
-import { getUser } from "@/features/user/_lib/fetcher";
+import { getUserWithArticles } from "@/features/user/_lib/fetcher";
 import { updatePartyMembersByLevel } from "@/features/party/data/partyMemberData";
 import * as Party from "@/features/party/components";
 import styles from "./PartyMemberCardList.module.css";
@@ -8,28 +7,11 @@ import styles from "./PartyMemberCardList.module.css";
  * PartyMemberCardList (Server Component)
  *
  * パーティメンバー一覧を取得して表示するServer Component
- *
- * データフェッチ:
- * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
- * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
  */
 const PartyMemberCardList = async () => {
 	try {
-		// ユーザー情報を取得（Request Memoization + use cache）
-		const user = await getUser();
-
-		// ゲストユーザーの判定
-		const zennUsername = user?.zennUsername || "aoyamadev";
-		const isGuestUser = !user?.zennUsername;
-
-		// Zenn記事を取得（use cache + Request Memoization）
-		const articles = await getZennArticles(zennUsername, { fetchAll: true });
-		const articleCount = articles.length;
-
-		// パーティメンバーデータを更新
+		const { articleCount, isGuestUser } = await getUserWithArticles();
 		const members = updatePartyMembersByLevel(articleCount);
-
-		// Client Componentにデータを渡す
 		return <Party.PartyMemberCardListClient members={members} isGuestUser={isGuestUser} />;
 	} catch (error) {
 		console.error("仲間データ取得エラー:", error);

--- a/src/features/posts/components/post-card/PostCard.tsx
+++ b/src/features/posts/components/post-card/PostCard.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import styles from "./PostCard.module.css";
 import { PlatformType } from "@/features/posts/types";
 import { useClickSound } from "@/components/common/audio/click-sound/ClickSound";
+import { formatDateShort } from "@/utils/formatDate";
+import { PLATFORM_INFO, CATEGORY_DISPLAY } from "@/consts/zenn";
 
 type PostCardProps = {
 	title: string;
@@ -12,29 +14,6 @@ type PostCardProps = {
 	category?: string;
 	publishedAt?: string;
 	platformType?: PlatformType;
-};
-
-const PLATFORM_INFO: Record<PlatformType, { name: string; favicon: string }> = {
-	zenn: {
-		name: "Zenn",
-		favicon: "https://zenn.dev/images/logo-transparent.png",
-	},
-} as Record<PlatformType, { name: string; favicon: string }>;
-
-// 日付をフォーマットする関数
-const formatDate = (dateString: string): string => {
-	const date = new Date(dateString);
-	return date.toLocaleDateString("ja-JP", {
-		year: "numeric",
-		month: "numeric",
-		day: "numeric",
-	});
-};
-
-// カテゴリー表示用のマッピング
-const CATEGORY_DISPLAY = {
-	tech: "TECH",
-	idea: "IDEA",
 };
 
 const PostCard = ({ title, url, category, publishedAt, platformType }: PostCardProps) => {
@@ -76,7 +55,7 @@ const PostCard = ({ title, url, category, publishedAt, platformType }: PostCardP
 					{/* 投稿日表示 */}
 					{publishedAt && (
 						<div className={`${styles["post-card__date-box"]}`}>
-							<span className={`${styles["post-card__date"]}`}>{formatDate(publishedAt)}</span>
+							<span className={`${styles["post-card__date"]}`}>{formatDateShort(publishedAt)}</span>
 						</div>
 					)}
 				</div>

--- a/src/features/posts/components/posts-list-with-data/PostsListWithData.tsx
+++ b/src/features/posts/components/posts-list-with-data/PostsListWithData.tsx
@@ -1,5 +1,4 @@
-import { getZennArticles } from "@/features/zenn/_lib/fetcher";
-import { getUser } from "@/features/user/_lib/fetcher";
+import { getUserWithArticles } from "@/features/user/_lib/fetcher";
 import { PlatformType } from "@/features/posts/types";
 import * as Posts from "@/features/posts/components";
 import styles from "./PostsListWithData.module.css";
@@ -8,21 +7,10 @@ import styles from "./PostsListWithData.module.css";
  * PostsListWithData (Server Component)
  *
  * Zenn記事一覧を取得して表示するServer Component
- *
- * データフェッチ:
- * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
- * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
  */
 const PostsListWithData = async () => {
 	try {
-		// ユーザー情報を取得（Request Memoization + use cache）
-		const user = await getUser();
-
-		// ゲストユーザーの判定
-		const zennUsername = user?.zennUsername || "aoyamadev";
-
-		// Zenn記事を取得（全件取得）- use cache + Request Memoization
-		const articles = await getZennArticles(zennUsername, { fetchAll: true });
+		const { articles } = await getUserWithArticles();
 
 		// platformType: "zenn" を各記事に設定
 		const postsData = articles.map((article) => ({

--- a/src/features/strength/components/strength-hero-info/StrengthHeroInfo.tsx
+++ b/src/features/strength/components/strength-hero-info/StrengthHeroInfo.tsx
@@ -1,5 +1,4 @@
-import { getZennArticles } from "@/features/zenn/_lib/fetcher";
-import { getUser } from "@/features/user/_lib/fetcher";
+import { getUserWithArticles } from "@/features/user/_lib/fetcher";
 import { strengthHeroData } from "@/features/strength/data/strengthHeroData";
 import * as Strength from "@/features/strength/components";
 import styles from "./StrengthHeroInfo.module.css";
@@ -8,44 +7,24 @@ import styles from "./StrengthHeroInfo.module.css";
  * StrengthHeroInfo (Server Component)
  *
  * 勇者のレベル情報を取得してStrengthHeroInfoClientに渡す
- * ItemCardList/PartyMemberCardListと同じパターンで2層分離
- *
- * データフェッチ:
- * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
- * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
  */
 const StrengthHeroInfo = async () => {
 	try {
-		// ユーザー情報を取得（Request Memoization + use cache）
-		const user = await getUser();
-
-		// ゲストユーザーの判定
-		const zennUsername = user?.zennUsername || "aoyamadev";
-
-		// Zenn記事数を取得（全件取得）
-		const articles = await getZennArticles(zennUsername, { fetchAll: true });
-		const articlesCount = articles.length;
+		const { zennUsername, articleCount } = await getUserWithArticles();
 
 		// レベル計算（1投稿 = 1レベル）
-		const calculatedLevel = Math.max(articlesCount, 1); // 最低レベル1
-		const currentExp = 40;
-		const nextLevelExp = 100;
-		const remainingArticles = 1;
+		const calculatedLevel = Math.max(articleCount, 1); // 最低レベル1
 
 		const heroData = {
 			...strengthHeroData,
 			level: calculatedLevel,
-			currentExp,
-			nextLevelExp,
-			remainingArticles,
+			currentExp: 40,
+			nextLevelExp: 100,
+			remainingArticles: 1,
 		};
 
-		// zennUsernameの表示形式
-		const displayZennUsername = `@${zennUsername}`;
-
-		// Client Componentにデータを渡す
 		return (
-			<Strength.StrengthHeroInfoClient heroData={heroData} zennUsername={displayZennUsername} />
+			<Strength.StrengthHeroInfoClient heroData={heroData} zennUsername={`@${zennUsername}`} />
 		);
 	} catch (error) {
 		console.error("Zenn記事の取得エラー:", error);

--- a/src/features/strength/components/strength-log-info-wrapper/StrengthLogInfoWrapper.tsx
+++ b/src/features/strength/components/strength-log-info-wrapper/StrengthLogInfoWrapper.tsx
@@ -1,35 +1,13 @@
-import { getZennArticles } from "@/features/zenn/_lib/fetcher";
-import { getUser } from "@/features/user/_lib/fetcher";
-import { getAdventureLogs, syncAdventureLogs } from "@/features/logs/services/logService";
+import { getAdventureLogsWithSync } from "@/features/logs/services/logService";
 import * as Strength from "@/features/strength/components";
 
 /**
  * StrengthLogInfoWrapper (Server Component)
  *
  * 冒険ログを同期・取得してStrengthLogInfoに渡す
- *
- * データフェッチ:
- * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
- * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
- * - syncAdventureLogs(): ログ同期
- * - getAdventureLogs(): DBからログ取得
  */
 const StrengthLogInfoWrapper = async () => {
-	// ユーザー情報を取得（Request Memoization + use cache）
-	const user = await getUser();
-
-	// 未ログインまたはZenn未連携の場合は空のログを表示
-	if (!user?.zennUsername) {
-		return <Strength.StrengthLogInfo logs={[]} />;
-	}
-
-	// Zenn記事を取得してログを同期
-	const articles = await getZennArticles(user.zennUsername, { fetchAll: true });
-	await syncAdventureLogs(user.id, articles);
-
-	// 同期後のログを取得して表示
-	const logs = await getAdventureLogs(user.clerkId);
-
+	const logs = await getAdventureLogsWithSync();
 	return <Strength.StrengthLogInfo logs={logs} />;
 };
 

--- a/src/features/strength/components/strength-title-info/StrengthTitleInfo.tsx
+++ b/src/features/strength/components/strength-title-info/StrengthTitleInfo.tsx
@@ -1,5 +1,4 @@
-import { getZennArticles } from "@/features/zenn/_lib/fetcher";
-import { getUser } from "@/features/user/_lib/fetcher";
+import { getUserWithArticles } from "@/features/user/_lib/fetcher";
 import styles from "./StrengthTitleInfo.module.css";
 import * as Strength from "@/features/strength/components";
 
@@ -7,24 +6,11 @@ import * as Strength from "@/features/strength/components";
  * StrengthTitleInfo (Server Component)
  *
  * 称号情報を取得してStrengthTitleInfoClientに渡す
- * StrengthHeroInfoと同じパターンで2層分離
- *
- * データフェッチ:
- * - getUser(): ユーザー認証とDB取得（Request Memoization + use cache）
- * - getZennArticles(): Zenn記事取得（Request Memoization + use cache）
  */
 const StrengthTitleInfo = async () => {
 	try {
-		// ユーザー情報を取得（Request Memoization + use cache）
-		const user = await getUser();
-
-		// ゲストユーザーの判定
-		const zennUsername = user?.zennUsername || "aoyamadev";
-		const isGuestUser = !user?.zennUsername;
-		const articles = await getZennArticles(zennUsername, { fetchAll: true });
-		const heroLevel = Math.max(articles.length, 1); // 最低レベル1
-
-		// Client Componentにデータを渡す
+		const { articleCount, isGuestUser } = await getUserWithArticles();
+		const heroLevel = Math.max(articleCount, 1); // 最低レベル1
 		return <Strength.StrengthTitleInfoClient heroLevel={heroLevel} isGuestUser={isGuestUser} />;
 	} catch (error) {
 		console.error("称号情報の取得エラー:", error);

--- a/src/features/user/_lib/fetcher.ts
+++ b/src/features/user/_lib/fetcher.ts
@@ -5,6 +5,8 @@ import { connection } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@clerk/nextjs/server";
 import { CacheTags } from "@/lib/cache-tags";
+import { getZennArticles } from "@/features/zenn/_lib/fetcher";
+import { PostData } from "@/features/posts/types";
 
 /**
  * ユーザー情報の型定義
@@ -97,3 +99,41 @@ export const getUser = cache(async (): Promise<User> => {
 export const preloadUser = () => {
 	void getUser(); // Promiseを開始するだけ（awaitしない）
 };
+
+/**
+ * ユーザー情報とZenn記事を一緒に取得する共通ユーティリティ
+ *
+ * 複数のコンポーネントで共通して使用されるデータフェッチパターンを抽象化。
+ * - StrengthHeroInfo, StrengthTitleInfo
+ * - ItemCardList, ItemDetailCard
+ * - PartyMemberCardList, PartyMemberDetailCard
+ * - PostsListWithData
+ *
+ * @returns ユーザー情報、Zennユーザー名、ゲストフラグ、記事一覧、記事数
+ */
+export type UserWithArticles = {
+	user: User;
+	zennUsername: string;
+	isGuestUser: boolean;
+	articles: PostData[];
+	articleCount: number;
+};
+
+export const getUserWithArticles = cache(async (): Promise<UserWithArticles> => {
+	const user = await getUser();
+
+	// ゲストユーザーの判定（Zenn未連携の場合はデモユーザー）
+	const zennUsername = user?.zennUsername || "aoyamadev";
+	const isGuestUser = !user?.zennUsername;
+
+	// Zenn記事を取得（全件取得）
+	const articles = await getZennArticles(zennUsername, { fetchAll: true });
+
+	return {
+		user,
+		zennUsername,
+		isGuestUser,
+		articles,
+		articleCount: articles.length,
+	};
+});

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,3 +1,12 @@
+/**
+ * 日付フォーマットユーティリティ
+ *
+ * 複数のコンポーネントで使用される日付フォーマット関数を統一
+ */
+
+/**
+ * 日付を「2025年1月25日」形式でフォーマット
+ */
 export const formatDate = (date: Date | string): string => {
 	const d = new Date(date);
 	return new Intl.DateTimeFormat("ja-JP", {
@@ -5,4 +14,34 @@ export const formatDate = (date: Date | string): string => {
 		month: "long",
 		day: "numeric",
 	}).format(d);
+};
+
+/**
+ * 日付を「2025/1/25」形式でフォーマット
+ * PostCard, DashboardActivityContent で使用
+ */
+export const formatDateShort = (date: Date | string | undefined): string => {
+	if (!date) return "";
+	const d = new Date(date);
+	return d.toLocaleDateString("ja-JP", {
+		year: "numeric",
+		month: "numeric",
+		day: "numeric",
+	});
+};
+
+/**
+ * 日付を「2025/01/25 14:30:00」形式でフォーマット（時分秒含む）
+ * logService で使用
+ */
+export const formatDateWithTime = (date: Date): string => {
+	return `${date.getFullYear()}/${(date.getMonth() + 1)
+		.toString()
+		.padStart(2, "0")}/${date.getDate().toString().padStart(2, "0")} ${date
+		.getHours()
+		.toString()
+		.padStart(2, "0")}:${date.getMinutes().toString().padStart(2, "0")}:${date
+		.getSeconds()
+		.toString()
+		.padStart(2, "0")}`;
 };


### PR DESCRIPTION
## Summary

Issue #106 で特定されたDRY原則違反を解消しました。

### 変更内容

#### 1. 冒険ログ取得ロジックの共通化
- `getAdventureLogsWithSync()` を `logService.ts` に追加
- `LogsListWrapper` と `StrengthLogInfoWrapper` の重複ロジックを削除

#### 2. ユーザー+記事取得ロジックの共通化
- `getUserWithArticles()` を `src/features/user/_lib/fetcher.ts` に追加
- 以下7つのコンポーネントの重複ロジックを削除:
  - `ItemCardList`
  - `ItemDetailCard`
  - `PartyMemberCardList`
  - `PartyMemberDetailCard`
  - `PostsListWithData`
  - `StrengthHeroInfo`
  - `StrengthTitleInfo`

#### 3. formatDate関数の統一
- `src/utils/formatDate.ts` に3つのフォーマット関数を集約:
  - `formatDate()` - 「2025年1月25日」形式
  - `formatDateShort()` - 「2025/1/25」形式
  - `formatDateWithTime()` - 「2025/01/25 14:30:00」形式

#### 4. Zenn関連定数の統一
- `src/consts/zenn.ts` を新規作成
- `PLATFORM_INFO` と `CATEGORY_DISPLAY` を共通化

### 効果
- **15ファイル変更**
- **253行削除、165行追加（約88行削減）**
- コードの保守性・可読性向上

## Test plan
- [x] `pnpm build` でビルド成功確認
- [x] `/logs` ページの動作確認
- [x] `/strength` ページの動作確認
- [x] `/items` ページの動作確認
- [x] `/party` ページの動作確認
- [x] `/posts` ページの動作確認
- [x] `/dashboard` ページの動作確認

Closes #106