### PR TITLE
refactor: ページ内インラインコンポーネントを分離 (#113)

### DIFF
--- a/src/app/(main)/connection/page.tsx
+++ b/src/app/(main)/connection/page.tsx
@@ -1,20 +1,11 @@
 import { Suspense } from "react";
-import * as Connection from "@/features/connection/components";
 import { getPageMetadata } from "@/config/metadata";
 import { Metadata } from "next";
 import LoadingIndicator from "@/components/common/loading-indicator/LoadingIndicator";
-import { getUser } from "@/features/user/_lib/fetcher";
 import styles from "./ConnectionPage.module.css";
+import ConnectionPageContent from "@/features/connection/components/connection-page-content/ConnectionPageContent";
 
 export const metadata: Metadata = getPageMetadata("connection");
-
-// Server Componentでユーザー情報を取得するラッパー
-const ConnectionPageContent = async () => {
-	const user = await getUser();
-	const initialZennUsername = user?.zennUsername ?? null;
-
-	return <Connection.ConnectionPageClient initialZennUsername={initialZennUsername} />;
-};
 
 export default function ConnectionPage() {
 	return (

--- a/src/app/(main)/explore/page.tsx
+++ b/src/app/(main)/explore/page.tsx
@@ -2,19 +2,10 @@ import { Suspense } from "react";
 import { Metadata } from "next";
 import { getPageMetadata } from "@/config/metadata";
 import styles from "./ExplorePage.module.css";
-import * as Explore from "@/features/explore/components";
 import LoadingIndicator from "@/components/common/loading-indicator/LoadingIndicator";
-import { getUser } from "@/features/user/_lib/fetcher";
+import ExplorePageContent from "@/features/explore/components/explore-page-content/ExplorePageContent";
 
 export const metadata: Metadata = getPageMetadata("explore");
-
-// Server Componentでユーザー情報を取得するラッパー
-const ExplorePageContent = async () => {
-	const user = await getUser();
-	const initialZennUsername = user?.zennUsername ?? null;
-
-	return <Explore.ExplorePageClient initialZennUsername={initialZennUsername} />;
-};
 
 const ExplorePage = () => {
 	return (

--- a/src/app/(main)/title/page.tsx
+++ b/src/app/(main)/title/page.tsx
@@ -2,19 +2,10 @@ import { Suspense } from "react";
 import { Metadata } from "next";
 import { getPageMetadata } from "@/config/metadata";
 import styles from "./TitlePage.module.css";
-import * as Title from "@/features/title/components";
 import LoadingIndicator from "@/components/common/loading-indicator/LoadingIndicator";
-import { getUser } from "@/features/user/_lib/fetcher";
+import TitlePageContent from "@/features/title/components/title-page-content/TitlePageContent";
 
 export const metadata: Metadata = getPageMetadata("title");
-
-// Server Componentでユーザー情報を取得するラッパー
-const TitlePageContent = async () => {
-	const user = await getUser();
-	const initialZennUsername = user?.zennUsername ?? null;
-
-	return <Title.TitlePageClient initialZennUsername={initialZennUsername} />;
-};
 
 const TitlePage = () => {
 	return (

--- a/src/features/connection/components/connection-page-content/ConnectionPageContent.tsx
+++ b/src/features/connection/components/connection-page-content/ConnectionPageContent.tsx
@@ -1,0 +1,12 @@
+import { getUser } from "@/features/user/_lib/fetcher";
+import ConnectionPageClient from "../connection-page-client/ConnectionPageClient";
+
+// Server Componentでユーザー情報を取得するラッパー
+const ConnectionPageContent = async () => {
+	const user = await getUser();
+	const initialZennUsername = user?.zennUsername ?? null;
+
+	return <ConnectionPageClient initialZennUsername={initialZennUsername} />;
+};
+
+export default ConnectionPageContent;

--- a/src/features/explore/components/explore-page-content/ExplorePageContent.tsx
+++ b/src/features/explore/components/explore-page-content/ExplorePageContent.tsx
@@ -1,0 +1,12 @@
+import { getUser } from "@/features/user/_lib/fetcher";
+import ExplorePageClient from "../explore-page-client/ExplorePageClient";
+
+// Server Componentでユーザー情報を取得するラッパー
+const ExplorePageContent = async () => {
+	const user = await getUser();
+	const initialZennUsername = user?.zennUsername ?? null;
+
+	return <ExplorePageClient initialZennUsername={initialZennUsername} />;
+};
+
+export default ExplorePageContent;

--- a/src/features/title/components/title-page-content/TitlePageContent.tsx
+++ b/src/features/title/components/title-page-content/TitlePageContent.tsx
@@ -1,0 +1,12 @@
+import { getUser } from "@/features/user/_lib/fetcher";
+import TitlePageClient from "../title-page-client/TitlePageClient";
+
+// Server Componentでユーザー情報を取得するラッパー
+const TitlePageContent = async () => {
+	const user = await getUser();
+	const initialZennUsername = user?.zennUsername ?? null;
+
+	return <TitlePageClient initialZennUsername={initialZennUsername} />;
+};
+
+export default TitlePageContent;


### PR DESCRIPTION
## Summary

- React/Next.jsの「コンポーネント細分化」原則に従い、`page.tsx` 内にインライン定義されていた Server Component を別ファイルに分離
- 1ディレクトリ=1コンポーネント規約との一貫性を確保

## 変更内容

| ページ | インラインコンポーネント | 移動先 |
|--------|-------------------------|--------|
| `/title` | `TitlePageContent` | `src/features/title/components/title-page-content/` |
| `/explore` | `ExplorePageContent` | `src/features/explore/components/explore-page-content/` |
| `/connection` | `ConnectionPageContent` | `src/features/connection/components/connection-page-content/` |

## 技術的な注意点

Server Component は `index.ts` からバレルエクスポートせず、`page.tsx` から直接インポートする。
これはNext.js App RouterでServer ComponentとClient Componentを同じindex.tsでエクスポートすると、
クライアントバンドルにサーバー専用コードが含まれてしまうため。

## Test plan

- [x] `pnpm build` でビルド成功
- [x] `/title` 正常表示
- [x] `/explore` 正常表示
- [x] `/connection` 正常表示

Closes #113