### PR TITLE
refactor: 相対インポートを絶対インポートに統一 (#115)

### DIFF
--- a/src/features/connection/api/index.ts
+++ b/src/features/connection/api/index.ts
@@ -1,4 +1,4 @@
-import { UserInfo, ZennArticle } from "../types";
+import { UserInfo, ZennArticle } from "@/features/connection/types";
 
 // ユーザー情報を取得するAPI
 export const fetchUserInfo = async (): Promise<{

--- a/src/features/connection/components/connection-page-content/ConnectionPageContent.tsx
+++ b/src/features/connection/components/connection-page-content/ConnectionPageContent.tsx
@@ -1,5 +1,5 @@
 import { getUser } from "@/features/user/_lib/fetcher";
-import ConnectionPageClient from "../connection-page-client/ConnectionPageClient";
+import ConnectionPageClient from "@/features/connection/components/connection-page-client/ConnectionPageClient";
 
 // Server Componentでユーザー情報を取得するラッパー
 const ConnectionPageContent = async () => {

--- a/src/features/connection/hooks/useSignOutHandler.ts
+++ b/src/features/connection/hooks/useSignOutHandler.ts
@@ -4,8 +4,8 @@ import "client-only";
 
 import { useEffect } from "react";
 import { useUser } from "@clerk/nextjs";
-import { UserInfo } from "../types";
-import { SESSION_ID_KEY, LOGOUT_FLAG_KEY } from "../constants";
+import { UserInfo } from "@/features/connection/types";
+import { SESSION_ID_KEY, LOGOUT_FLAG_KEY } from "@/features/connection/constants";
 
 interface UseSignOutHandlerProps {
 	userInfo: UserInfo | null;

--- a/src/features/connection/hooks/useUserInfo.ts
+++ b/src/features/connection/hooks/useUserInfo.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useUser } from "@clerk/nextjs";
-import { UserInfo } from "../types";
-import { fetchUserInfo } from "../api";
+import { UserInfo } from "@/features/connection/types";
+import { fetchUserInfo } from "@/features/connection/api";
 
 interface UseUserInfoProps {
 	wasLoggedOut: boolean;

--- a/src/features/connection/hooks/useZennConnection.ts
+++ b/src/features/connection/hooks/useZennConnection.ts
@@ -2,15 +2,15 @@ import { useState } from "react";
 import { useUser } from "@clerk/nextjs";
 import { useHero } from "@/contexts/HeroContext";
 import { revalidateAfterZennConnection } from "@/features/user/_actions/revalidate";
-import { UserInfo } from "../types";
-import { cleanUsername, isValidZennUsernameFormat } from "../utils";
-import { SUSPICIOUS_FIXED_COUNT } from "../constants";
+import { UserInfo } from "@/features/connection/types";
+import { cleanUsername, isValidZennUsernameFormat } from "@/features/connection/utils";
+import { SUSPICIOUS_FIXED_COUNT } from "@/features/connection/constants";
 import {
 	checkZennUser,
 	updateUserProfile as updateUserProfileApi,
 	syncZennArticles as syncZennArticlesApi,
 	updateArticleCount,
-} from "../api";
+} from "@/features/connection/api";
 
 interface UseZennConnectionProps {
 	playClickSound: (callback?: () => void) => void;

--- a/src/features/connection/hooks/useZennSync.ts
+++ b/src/features/connection/hooks/useZennSync.ts
@@ -3,14 +3,14 @@ import { useUser } from "@clerk/nextjs";
 import { useHero } from "@/contexts/HeroContext";
 import { revalidateAfterZennConnection } from "@/features/user/_actions/revalidate";
 
-import { UserInfo } from "../types";
-import { cleanUsername, isValidZennUsernameFormat } from "../utils";
-import { SUSPICIOUS_FIXED_COUNT } from "../constants";
+import { UserInfo } from "@/features/connection/types";
+import { cleanUsername, isValidZennUsernameFormat } from "@/features/connection/utils";
+import { SUSPICIOUS_FIXED_COUNT } from "@/features/connection/constants";
 import {
 	syncZennArticles as syncZennArticlesApi,
 	updateUserProfile as updateUserProfileApi,
 	updateArticleCount,
-} from "../api";
+} from "@/features/connection/api";
 
 interface UseZennSyncProps {
 	userInfo: UserInfo | null;

--- a/src/features/dashboard/components/dashboard-content/DashboardContent.tsx
+++ b/src/features/dashboard/components/dashboard-content/DashboardContent.tsx
@@ -2,18 +2,18 @@ import { Suspense } from "react";
 import styles from "./DashboardContent.module.css";
 
 // Components
-import DashboardHeroSection from "../dashboard-hero-section/DashboardHeroSection";
-import DashboardPlatformStatsSection from "../dashboard-platform-stats-section/DashboardPlatformStatsSection";
-import DashboardActivitySection from "../dashboard-activity-section/DashboardActivitySection";
-import DashboardLatestPartyMemberSection from "../dashboard-latest-party-member-section/DashboardLatestPartyMemberSection";
-import DashboardLatestItemSection from "../dashboard-latest-item-section/DashboardLatestItemSection";
+import DashboardHeroSection from "@/features/dashboard/components/dashboard-hero-section/DashboardHeroSection";
+import DashboardPlatformStatsSection from "@/features/dashboard/components/dashboard-platform-stats-section/DashboardPlatformStatsSection";
+import DashboardActivitySection from "@/features/dashboard/components/dashboard-activity-section/DashboardActivitySection";
+import DashboardLatestPartyMemberSection from "@/features/dashboard/components/dashboard-latest-party-member-section/DashboardLatestPartyMemberSection";
+import DashboardLatestItemSection from "@/features/dashboard/components/dashboard-latest-item-section/DashboardLatestItemSection";
 
 // Skeletons
-import DashboardHeroSkeleton from "../dashboard-hero-skeleton/DashboardHeroSkeleton";
-import DashboardPlatformStatsSkeleton from "../dashboard-platform-stats-skeleton/DashboardPlatformStatsSkeleton";
-import DashboardActivitySkeleton from "../dashboard-activity-skeleton/DashboardActivitySkeleton";
-import DashboardLatestPartyMemberSkeleton from "../dashboard-latest-party-member-skeleton/DashboardLatestPartyMemberSkeleton";
-import DashboardLatestItemSkeleton from "../dashboard-latest-item-skeleton/DashboardLatestItemSkeleton";
+import DashboardHeroSkeleton from "@/features/dashboard/components/dashboard-hero-skeleton/DashboardHeroSkeleton";
+import DashboardPlatformStatsSkeleton from "@/features/dashboard/components/dashboard-platform-stats-skeleton/DashboardPlatformStatsSkeleton";
+import DashboardActivitySkeleton from "@/features/dashboard/components/dashboard-activity-skeleton/DashboardActivitySkeleton";
+import DashboardLatestPartyMemberSkeleton from "@/features/dashboard/components/dashboard-latest-party-member-skeleton/DashboardLatestPartyMemberSkeleton";
+import DashboardLatestItemSkeleton from "@/features/dashboard/components/dashboard-latest-item-skeleton/DashboardLatestItemSkeleton";
 
 const DashboardContent = () => {
 	return (

--- a/src/features/dashboard/data/dashboardData.ts
+++ b/src/features/dashboard/data/dashboardData.ts
@@ -1,4 +1,4 @@
-import { DashboardData } from "../types/dashboard.types";
+import { DashboardData } from "@/features/dashboard/types/dashboard.types";
 
 // 開発用の初期データ
 export const dashboardData: DashboardData = {

--- a/src/features/explore/components/explore-page-content/ExplorePageContent.tsx
+++ b/src/features/explore/components/explore-page-content/ExplorePageContent.tsx
@@ -1,5 +1,5 @@
 import { getUser } from "@/features/user/_lib/fetcher";
-import ExplorePageClient from "../explore-page-client/ExplorePageClient";
+import ExplorePageClient from "@/features/explore/components/explore-page-client/ExplorePageClient";
 
 // Server Componentでユーザー情報を取得するラッパー
 const ExplorePageContent = async () => {

--- a/src/features/home/data/homeCharacterImages.ts
+++ b/src/features/home/data/homeCharacterImages.ts
@@ -1,4 +1,4 @@
-import { CharacterImage } from "../types/homeCharacter.types";
+import { CharacterImage } from "@/features/home/types/homeCharacter.types";
 
 export const homeCharacterImages: CharacterImage[] = [
 	{

--- a/src/features/items/data/itemsData.ts
+++ b/src/features/items/data/itemsData.ts
@@ -1,4 +1,4 @@
-import { Item, ItemsData } from "../types/items.types";
+import { Item, ItemsData } from "@/features/items/types/items.types";
 
 // キー（アイテムID）と値（勇者のレベル）の関係
 export const heroLevelAndItemRelation: { [key: number]: number } = {

--- a/src/features/navigation/data/navigationItems.ts
+++ b/src/features/navigation/data/navigationItems.ts
@@ -1,4 +1,4 @@
-import { NavigationItem } from "../types/navigation.types";
+import { NavigationItem } from "@/features/navigation/types/navigation.types";
 
 export const navigationItems: NavigationItem[] = [
 	{

--- a/src/features/party-member/components/party-member-detail-card/PartyMemberDetailCard.tsx
+++ b/src/features/party-member/components/party-member-detail-card/PartyMemberDetailCard.tsx
@@ -7,7 +7,7 @@ import {
 	customMemberImages,
 	customMemberSilhouetteImages,
 } from "@/features/party/data/partyMemberData";
-import PartyMemberDetailCardClient from "../party-member-detail-card-client/PartyMemberDetailCardClient";
+import PartyMemberDetailCardClient from "@/features/party-member/components/party-member-detail-card-client/PartyMemberDetailCardClient";
 import styles from "./PartyMemberDetailCard.module.css";
 
 interface PartyMemberDetailCardProps {

--- a/src/features/party/components/party-member-card-list-client/PartyMemberCardListClient.tsx
+++ b/src/features/party/components/party-member-card-list-client/PartyMemberCardListClient.tsx
@@ -8,7 +8,7 @@ import { useRouter } from "next/navigation";
 import { useClickSound } from "@/components/common/audio/click-sound/ClickSound";
 import { PartyMember } from "@/features/party/types/party.types";
 import { customMemberSilhouetteImages } from "@/features/party/data/partyMemberData";
-import PartyListSkeleton from "../party-list-skeleton/PartyListSkeleton";
+import PartyListSkeleton from "@/features/party/components/party-list-skeleton/PartyListSkeleton";
 
 interface PartyMemberCardListClientProps {
 	members: PartyMember[];

--- a/src/features/party/data/partyMemberData.ts
+++ b/src/features/party/data/partyMemberData.ts
@@ -1,4 +1,4 @@
-import { PartyMember, PartyData } from "../types/party.types";
+import { PartyMember, PartyData } from "@/features/party/types/party.types";
 
 // メンバーIDと必要な勇者レベルの関係
 // キー: メンバーID, 値: そのメンバーを獲得するために必要な勇者レベル

--- a/src/features/posts/services/zenn-service.ts
+++ b/src/features/posts/services/zenn-service.ts
@@ -1,4 +1,4 @@
-import { PostData } from "../types";
+import { PostData } from "@/features/posts/types";
 
 // APIから記事データを取得する関数
 export const fetchZennArticles = async (

--- a/src/features/title/components/title-page-content/TitlePageContent.tsx
+++ b/src/features/title/components/title-page-content/TitlePageContent.tsx
@@ -1,5 +1,5 @@
 import { getUser } from "@/features/user/_lib/fetcher";
-import TitlePageClient from "../title-page-client/TitlePageClient";
+import TitlePageClient from "@/features/title/components/title-page-client/TitlePageClient";
 
 // Server Componentでユーザー情報を取得するラッパー
 const TitlePageContent = async () => {


### PR DESCRIPTION
## Summary

- features 内の相対インポート（`../`）を絶対インポート（`@/features/...`）に統一
- コードの可読性向上とファイル移動時の保守性を改善

## 変更例

```diff
- import { UserInfo } from "../types";
+ import { UserInfo } from "@/features/connection/types";
```

## 対象

- `src/features/connection/` - 6ファイル
- `src/features/dashboard/` - 2ファイル
- `src/features/explore/` - 1ファイル
- `src/features/home/` - 1ファイル
- `src/features/items/` - 1ファイル
- `src/features/navigation/` - 1ファイル
- `src/features/party/` - 2ファイル
- `src/features/party-member/` - 1ファイル
- `src/features/posts/` - 1ファイル
- `src/features/title/` - 1ファイル

## Test plan

- [ ] `pnpm build` でビルド成功
- [ ] 各ページが正常に動作することを確認

Closes #115