### PR TITLE
style: CSS display二値構文の統一 (#117)

### DIFF
--- a/src/app/(main)/strength/StrengthPage.module.css
+++ b/src/app/(main)/strength/StrengthPage.module.css
@@ -19,7 +19,7 @@
 }
 
 .strength-container {
-	display: grid;
+	display: block grid;
 	height: 100%;
 	border: var(--border-large);
 	border-radius: var(--border-radius-small);
@@ -45,7 +45,7 @@
 .strength-content {
 	width: 100%;
 	height: 100%;
-	display: grid;
+	display: block grid;
 	grid-template-columns: 1fr 1fr;
 	gap: 15px;
 	overflow-y: scroll;

--- a/src/features/dashboard/components/dashboard-content/DashboardContent.module.css
+++ b/src/features/dashboard/components/dashboard-content/DashboardContent.module.css
@@ -1,5 +1,5 @@
 .dashboard-content-container {
-	display: grid;
+	display: block grid;
 	grid-template-columns: auto;
 	grid-auto-rows: minmax(min-content, max-content);
 	gap: 25px;
@@ -11,7 +11,7 @@
 
 .dashboard-zenn-area {
 	width: 100%;
-	display: grid;
+	display: block grid;
 	grid-template-columns: auto 1fr;
 	gap: 35px;
 	padding-inline: 20px;

--- a/src/features/dashboard/components/dashboard-hero-section/DashboardHeroSection.module.css
+++ b/src/features/dashboard/components/dashboard-hero-section/DashboardHeroSection.module.css
@@ -204,7 +204,7 @@
 	place-content: center;
 	place-items: center;
 	padding-inline: 12px;
-	display: grid;
+	display: block grid;
 }
 
 .hero-info-level-display {

--- a/src/features/dashboard/components/dashboard-hero-skeleton/DashboardHeroSkeleton.module.css
+++ b/src/features/dashboard/components/dashboard-hero-skeleton/DashboardHeroSkeleton.module.css
@@ -1,6 +1,6 @@
 /* matches hero-info-section */
 .skeleton-hero-section {
-	display: grid;
+	display: block grid;
 	gap: 35px;
 	padding-block-start: 10px;
 	padding-inline: 20px;
@@ -9,7 +9,7 @@
 /* matches hero-info-title */
 .skeleton-hero-title {
 	position: relative;
-	display: grid;
+	display: block grid;
 	font-size: 1.25rem;
 	font-weight: var(--font-weight-x-bold);
 	line-height: var(--leading-x-tight);
@@ -25,7 +25,7 @@
 /* matches hero-info-container */
 .skeleton-hero-container {
 	width: 100%;
-	display: grid;
+	display: block grid;
 	place-items: center;
 	padding-inline: 20px;
 
@@ -37,7 +37,7 @@
 /* matches hero-info */
 .skeleton-hero-info {
 	width: 100%;
-	display: grid;
+	display: block grid;
 	grid-template-columns: repeat(2, auto);
 	gap: 20px;
 
@@ -48,7 +48,7 @@
 
 /* matches hero-info-box */
 .skeleton-hero-box {
-	display: grid;
+	display: block grid;
 	grid-template-columns: auto;
 	grid-template-rows: auto auto 1fr;
 	grid-template-areas:
@@ -64,7 +64,7 @@
 	grid-area: icon;
 	width: 170px;
 	height: 170px;
-	display: grid;
+	display: block grid;
 	place-items: center;
 	border: 3mm ridge var(--color-border-primary);
 
@@ -116,14 +116,14 @@
 
 /* matches hero-info-level */
 .skeleton-hero-level {
-	display: grid;
+	display: block grid;
 	grid-template-columns: auto;
 	gap: 60px;
 }
 
 /* matches hero-info-level-header */
 .skeleton-hero-level-header {
-	display: grid;
+	display: block grid;
 	grid-template-columns: auto;
 	grid-template-rows: auto;
 	justify-content: end;
@@ -139,7 +139,7 @@
 .skeleton-hero-level-display {
 	min-width: 150px;
 	height: 105px;
-	display: grid;
+	display: block grid;
 	place-self: end;
 	background: linear-gradient(
 		90deg,
@@ -174,7 +174,7 @@
 
 /* matches hero-info-level-progress-box */
 .skeleton-hero-progress-box {
-	display: grid;
+	display: block grid;
 	gap: 12px;
 }
 
@@ -195,7 +195,7 @@
 
 /* matches hero-info-level-progress-gauge-container */
 .skeleton-hero-progress-gauge-container {
-	display: flex;
+	display: block flex;
 	align-items: center;
 	gap: 8px;
 }

--- a/src/features/dashboard/components/dashboard-latest-item-skeleton/DashboardLatestItemSkeleton.module.css
+++ b/src/features/dashboard/components/dashboard-latest-item-skeleton/DashboardLatestItemSkeleton.module.css
@@ -1,7 +1,7 @@
 /* matches latest-item-section */
 .skeleton-latest-section {
 	width: 100%;
-	display: grid;
+	display: block grid;
 	grid-template-rows: auto 1fr;
 	gap: 35px;
 	padding-block: 20px;
@@ -31,7 +31,7 @@
 /* matches latest-item-container */
 .skeleton-last-item-container {
 	width: 100%;
-	display: grid;
+	display: block grid;
 	place-self: start;
 	gap: 10px;
 	padding-inline: 25px;

--- a/src/features/dashboard/components/dashboard-latest-party-member-skeleton/DashboardLatestPartyMemberSkeleton.module.css
+++ b/src/features/dashboard/components/dashboard-latest-party-member-skeleton/DashboardLatestPartyMemberSkeleton.module.css
@@ -1,7 +1,7 @@
 /* matches latest-party-member-section (and latest-item-section) */
 .skeleton-latest-section {
 	width: 100%;
-	display: grid;
+	display: block grid;
 	grid-template-rows: auto 1fr;
 	gap: 35px;
 	padding-block: 20px;
@@ -23,7 +23,7 @@
 	}
 }
 
-.skeleton-section-title-icon{
+.skeleton-section-title-icon {
 	width: 20px;
 	height: auto;
 }
@@ -31,7 +31,7 @@
 /* matches latest-party-member-container */
 .skeleton-party-member-container {
 	width: 100%;
-	display: grid;
+	display: block grid;
 	place-self: start;
 	gap: 10px;
 	padding-inline: 25px;

--- a/src/features/dashboard/components/dashboard-platform-stats-skeleton/DashboardPlatformStatsSkeleton.module.css
+++ b/src/features/dashboard/components/dashboard-platform-stats-skeleton/DashboardPlatformStatsSkeleton.module.css
@@ -24,7 +24,7 @@
 /* matches platform-stats-section */
 .skeleton-platform-stats {
 	width: 100%;
-	display: grid;
+	display: block grid;
 	grid-template-rows: auto 1fr;
 	gap: 15px;
 }
@@ -32,7 +32,7 @@
 /* matches platform-stats-container */
 .skeleton-platform-stats-container {
 	width: 100%;
-	display: grid;
+	display: block grid;
 	place-self: start;
 	gap: 10px;
 	margin-block-start: 20px;

--- a/src/features/item-detail/components/item-detail-skeleton/ItemDetailSkeleton.module.css
+++ b/src/features/item-detail/components/item-detail-skeleton/ItemDetailSkeleton.module.css
@@ -1,5 +1,5 @@
 .skeleton-wrapper {
-	display: grid;
+	display: block grid;
 	place-items: center;
 	padding-inline: 25px;
 	padding-block: 40px;
@@ -76,7 +76,12 @@
 .skeleton-image {
 	width: 100%;
 	height: 100%;
-	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
+	background: linear-gradient(
+		90deg,
+		var(--color-skeleton-base) 25%,
+		var(--color-skeleton-highlight) 50%,
+		var(--color-skeleton-base) 75%
+	);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 }
@@ -99,7 +104,12 @@
 .skeleton-title {
 	width: 100%;
 	height: 100%;
-	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
+	background: linear-gradient(
+		90deg,
+		var(--color-skeleton-base) 25%,
+		var(--color-skeleton-highlight) 50%,
+		var(--color-skeleton-base) 75%
+	);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 }
@@ -118,7 +128,12 @@
 	width: 100%;
 	height: 100%;
 	min-height: 80px;
-	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
+	background: linear-gradient(
+		90deg,
+		var(--color-skeleton-base) 25%,
+		var(--color-skeleton-highlight) 50%,
+		var(--color-skeleton-base) 75%
+	);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 }

--- a/src/features/party-member/components/party-member-detail-skeleton/PartyMemberDetailSkeleton.module.css
+++ b/src/features/party-member/components/party-member-detail-skeleton/PartyMemberDetailSkeleton.module.css
@@ -1,5 +1,5 @@
 .skeleton-wrapper {
-	display: grid;
+	display: block grid;
 	place-items: center;
 	padding-inline: 25px;
 	padding-block: 40px;
@@ -76,7 +76,12 @@
 .skeleton-image {
 	width: 100%;
 	height: 100%;
-	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
+	background: linear-gradient(
+		90deg,
+		var(--color-skeleton-base) 25%,
+		var(--color-skeleton-highlight) 50%,
+		var(--color-skeleton-base) 75%
+	);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 }
@@ -99,7 +104,12 @@
 .skeleton-title {
 	width: 100%;
 	height: 100%;
-	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
+	background: linear-gradient(
+		90deg,
+		var(--color-skeleton-base) 25%,
+		var(--color-skeleton-highlight) 50%,
+		var(--color-skeleton-base) 75%
+	);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 }
@@ -118,7 +128,12 @@
 	width: 100%;
 	height: 100%;
 	min-height: 80px;
-	background: linear-gradient(90deg, var(--color-skeleton-base) 25%, var(--color-skeleton-highlight) 50%, var(--color-skeleton-base) 75%);
+	background: linear-gradient(
+		90deg,
+		var(--color-skeleton-base) 25%,
+		var(--color-skeleton-highlight) 50%,
+		var(--color-skeleton-base) 75%
+	);
 	background-size: 200% 100%;
 	animation: shimmer 1.5s infinite;
 }

--- a/src/features/strength/components/strength-log-info-skeleton/StrengthLogInfoSkeleton.module.css
+++ b/src/features/strength/components/strength-log-info-skeleton/StrengthLogInfoSkeleton.module.css
@@ -109,6 +109,6 @@
 
 .skeleton-list {
 	min-height: 208px;
-	display: grid;
+	display: block grid;
 	place-items: center;
 }


### PR DESCRIPTION
## Summary

- CSS Display Module Level 3 の二値構文（two-value syntax）を統一
- 二値構文になっていない箇所を修正

## 変更内容

```diff
- display: grid;
+ display: block grid;

- display: flex;
+ display: block flex;
```

## 対象ファイル（10ファイル）

- `StrengthPage.module.css`
- `DashboardContent.module.css`
- `DashboardHeroSection.module.css`
- `DashboardHeroSkeleton.module.css`
- `DashboardLatestItemSkeleton.module.css`
- `DashboardLatestPartyMemberSkeleton.module.css`
- `DashboardPlatformStatsSkeleton.module.css`
- `ItemDetailSkeleton.module.css`
- `PartyMemberDetailSkeleton.module.css`
- `StrengthLogInfoSkeleton.module.css`

## 参考

- [CSS Display Module Level 3](https://www.w3.org/TR/css-display-3/)

## Test plan

- [x] `pnpm build` でビルド成功
- [x] 各ページのレイアウトが崩れていないことを確認

Closes #117