### PR TITLE
refactor: CSS冗長コードを削除

### DIFF
--- a/src/components/common/loading-indicator/LoadingIndicator.module.css
+++ b/src/components/common/loading-indicator/LoadingIndicator.module.css
@@ -26,18 +26,6 @@
 .loading-dot {
 	animation: loading-dot-appear 1.5s infinite;
 	opacity: 0;
-
-	&:nth-child(1) {
-		animation-delay: 0s;
-	}
-
-	&:nth-child(2) {
-		animation-delay: 0s;
-	}
-
-	&:nth-child(3) {
-		animation-delay: 0s;
-	}
 }
 
 @keyframes loading-dot-appear {
@@ -64,10 +52,6 @@
 		opacity: 0;
 		transform: scale(1);
 	}
-}
-
-.loading-dot:nth-child(1) {
-	animation-delay: 0s;
 }
 
 .loading-dot:nth-child(2) {

--- a/src/features/dashboard/components/dashboard-hero-section/DashboardHeroSection.module.css
+++ b/src/features/dashboard/components/dashboard-hero-section/DashboardHeroSection.module.css
@@ -322,18 +322,12 @@
 	animation: loading-dot-appear 1.5s infinite;
 	opacity: 0;
 
-	&:nth-child(1) {
-		animation-delay: 0s;
-	}
-
 	&:nth-child(2) {
 		animation-name: loading-dot-appear-2;
-		animation-delay: 0s;
 	}
 
 	&:nth-child(3) {
 		animation-name: loading-dot-appear-3;
-		animation-delay: 0s;
 	}
 }
 
@@ -349,18 +343,12 @@
 	animation: loading-dot-appear 1.5s infinite;
 	opacity: 0;
 
-	&:nth-child(1) {
-		animation-delay: 0s;
-	}
-
 	&:nth-child(2) {
 		animation-name: loading-dot-appear-2;
-		animation-delay: 0s;
 	}
 
 	&:nth-child(3) {
 		animation-name: loading-dot-appear-3;
-		animation-delay: 0s;
 	}
 }
 

--- a/src/features/dashboard/components/dashboard-platform-stats-section/DashboardPlatformStatsSection.module.css
+++ b/src/features/dashboard/components/dashboard-platform-stats-section/DashboardPlatformStatsSection.module.css
@@ -178,18 +178,12 @@
 	animation: loading-dot-appear 1.5s infinite;
 	opacity: 0;
 
-	&:nth-child(1) {
-		animation-delay: 0s;
-	}
-
 	&:nth-child(2) {
 		animation-name: loading-dot-appear-2;
-		animation-delay: 0s;
 	}
 
 	&:nth-child(3) {
 		animation-name: loading-dot-appear-3;
-		animation-delay: 0s;
 	}
 }
 

--- a/src/features/explore/components/explore-article-analysis/ExploreArticleAnalysis.module.css
+++ b/src/features/explore/components/explore-article-analysis/ExploreArticleAnalysis.module.css
@@ -206,18 +206,12 @@
 	animation: loading-dot-appear 1.5s infinite;
 	opacity: 0;
 
-	&:nth-child(1) {
-		animation-delay: 0s;
-	}
-
 	&:nth-child(2) {
 		animation-name: loading-dot-appear-2;
-		animation-delay: 0s;
 	}
 
 	&:nth-child(3) {
 		animation-name: loading-dot-appear-3;
-		animation-delay: 0s;
 	}
 }
 

--- a/src/features/explore/components/explore-page-client/ExplorePageClient.module.css
+++ b/src/features/explore/components/explore-page-client/ExplorePageClient.module.css
@@ -107,18 +107,12 @@
 	animation: loading-dot-appear 1.5s infinite;
 	opacity: 0;
 
-	&:nth-child(1) {
-		animation-delay: 0s;
-	}
-
 	&:nth-child(2) {
 		animation-name: loading-dot-appear-2;
-		animation-delay: 0s;
 	}
 
 	&:nth-child(3) {
 		animation-name: loading-dot-appear-3;
-		animation-delay: 0s;
 	}
 }
 

--- a/src/features/posts/components/post-card/PostCard.module.css
+++ b/src/features/posts/components/post-card/PostCard.module.css
@@ -37,7 +37,6 @@
 	}
 }
 
-/* 新しいスタイル */
 .post-card__info {
 	display: block flex;
 	align-items: center;

--- a/src/features/title/components/title-page-header/TitlePageHeader.module.css
+++ b/src/features/title/components/title-page-header/TitlePageHeader.module.css
@@ -81,10 +81,6 @@
 	opacity: 0;
 }
 
-.loading-dot:nth-child(1) {
-	animation-delay: 0s;
-}
-
 .loading-dot:nth-child(2) {
 	animation-name: loading-dot-appear-2;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -264,17 +264,6 @@
 		--chart-4: 280 65% 60%;
 		--chart-5: 340 75% 55%;
 	}
-}
-
-@layer base {
-	* {
-	}
-	body {
-		@apply bg-background text-foreground;
-	}
-}
-
-@layer base {
 	* {
 		@apply border-border outline-ring/50;
 	}


### PR DESCRIPTION
## Summary

- `animation-delay: 0s` を6ファイルから削除（デフォルト値のため不要）
- `globals.css` の重複した `@layer base` と空ルールを削除
- `PostCard.module.css` の古いコメント `/* 新しいスタイル */` を削除

## 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `LoadingIndicator.module.css` | `animation-delay: 0s` 削除 |
| `DashboardHeroSection.module.css` | `animation-delay: 0s` 削除 |
| `DashboardPlatformStatsSection.module.css` | `animation-delay: 0s` 削除 |
| `ExploreArticleAnalysis.module.css` | `animation-delay: 0s` 削除 |
| `ExplorePageClient.module.css` | `animation-delay: 0s` 削除 |
| `TitlePageHeader.module.css` | `animation-delay: 0s` 削除 |
| `globals.css` | 重複 `@layer base` と空ルール削除 |
| `PostCard.module.css` | 古いコメント削除 |

## Test plan

- [x] `pnpm build` 成功確認

Closes #119