### PR TITLE
refactor: ConnectionコンポーネントのinputをCSS Modules化

### DIFF
--- a/src/features/connection/components/connection-auth-section/ConnectionAuthSection.tsx
+++ b/src/features/connection/components/connection-auth-section/ConnectionAuthSection.tsx
@@ -68,7 +68,7 @@ const ConnectionAuthSection: React.FC<ConnectionAuthSectionProps> = ({
 						type="text"
 						value=""
 						onChange={() => {}}
-						className="flex-1 border-[3px] border-gray-400 bg-white rounded px-3 py-2 text-black cursor-not-allowed min-w-0"
+						className={styles["zenn-input-disabled"]}
 						placeholder="例: aoyamadev"
 						disabled
 					/>

--- a/src/features/connection/components/connection-zenn-form/ConnectionZennForm.tsx
+++ b/src/features/connection/components/connection-zenn-form/ConnectionZennForm.tsx
@@ -60,7 +60,7 @@ const ConnectionZennForm = memo<ConnectionZennFormProps>(function ConnectionZenn
 					type="text"
 					value={localUsername}
 					onChange={(e) => handleChange(e.target.value)}
-					className="flex-1 border-[3px] border-gray-400 bg-white rounded px-3 py-2 text-black"
+					className={styles["zenn-input"]}
 					placeholder="例: aoyamadev"
 					disabled={loading}
 				/>


### PR DESCRIPTION
## Summary

- Tailwindインラインクラスを CSS Modules に移行
- `ConnectionAuthSection.tsx`: `.zenn-input-disabled` クラス使用
- `ConnectionZennForm.tsx`: `.zenn-input` クラス使用

## 依存関係

- #125 （CSS Modulesに `.zenn-input-disabled`, `.zenn-input` クラスを追加済み）

## Test plan

- [x] ビルド確認

Closes #123