### PR TITLE
refactor: 未使用CSS変数の削除とスタイル微調整

### DIFF
--- a/src/features/connection/components/connection-message-display/ConnectionMessageDisplay.module.css
+++ b/src/features/connection/components/connection-message-display/ConnectionMessageDisplay.module.css
@@ -17,7 +17,7 @@
 
 .release-message {
 	color: var(--color-primary-white);
-	background-color: var(--bg-color-message-release);
+	background-color: var(--color-primary-black);
 }
 
 .error-message {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -77,7 +77,6 @@
 		--pixel-shadow-medium: 1px 2px 0.5px #454545;
 
 		/* メッセージ関連のカラー */
-		--bg-color-message-release: #000;
 		--bg-color-message-error: #d71313;
 		--bg-color-message-success: #29ab1c;
 


### PR DESCRIPTION
## Summary

- `globals.css`: 未使用の `--bg-color-message-release` 削除
- `ConnectionMessageDisplay.module.css`: CSS変数参照を `--color-primary-black` に変更

## Test plan

- [x] ビルド確認

Closes #124