### PR TITLE
perf: Imageコンポーネントにplaceholder="blur"を追加

### DIFF
--- a/src/features/about/components/about-guide-icon-client/AboutGuideIconClient.tsx
+++ b/src/features/about/components/about-guide-icon-client/AboutGuideIconClient.tsx
@@ -17,8 +17,8 @@ const AboutGuideIconClient: React.FC<AboutGuideIconClientProps> = ({ iconSrc, al
 			<Image
 				src={iconSrc}
 				alt={alt}
-				width={1000}
-				height={1000}
+				width={100}
+				height={100}
 				preload={true}
 				onLoad={onImageLoad}
 				className={styles["about-guide-icon-image"]}

--- a/src/features/dashboard/components/dashboard-activity-content/DashboardActivityContent.tsx
+++ b/src/features/dashboard/components/dashboard-activity-content/DashboardActivityContent.tsx
@@ -27,6 +27,7 @@ const DashboardActivityContent = ({ articles }: DashboardActivityContentProps) =
 					alt="王冠"
 					width={100}
 					height={100}
+					preload={true}
 					className={`${styles["recent-activity-section-title-icon"]}`}
 				/>
 				<span>最近の記録</span>

--- a/src/features/dashboard/components/dashboard-activity-skeleton/DashboardActivitySkeleton.tsx
+++ b/src/features/dashboard/components/dashboard-activity-skeleton/DashboardActivitySkeleton.tsx
@@ -10,6 +10,7 @@ const DashboardActivitySkeleton = () => {
 					alt="王冠"
 					width={100}
 					height={100}
+					preload={true}
 					className={`${styles["skeleton-activity-title-icon"]}`}
 				/>
 				<span>最近の記録</span>

--- a/src/features/dashboard/components/dashboard-hero-icon-client/DashboardHeroIconClient.module.css
+++ b/src/features/dashboard/components/dashboard-hero-icon-client/DashboardHeroIconClient.module.css
@@ -4,20 +4,6 @@
 	filter: drop-shadow(0px 2px 1.5px var(--color-primary-black));
 }
 
-.dashboard-hero-icon-skeleton {
-	position: absolute;
-	inset: 0;
-	background: linear-gradient(
-		90deg,
-		var(--color-skeleton-base) 25%,
-		var(--color-skeleton-highlight) 50%,
-		var(--color-skeleton-base) 75%
-	);
-	background-size: 200% 100%;
-	animation: skeleton-shimmer 1.5s ease-in-out infinite;
-	border-radius: var(--border-radius-medium);
-}
-
 @keyframes skeleton-shimmer {
 	0% {
 		background-position: 200% 0;

--- a/src/features/dashboard/components/dashboard-hero-icon-client/DashboardHeroIconClient.tsx
+++ b/src/features/dashboard/components/dashboard-hero-icon-client/DashboardHeroIconClient.tsx
@@ -3,28 +3,22 @@
 import Image from "next/image";
 import heroPlateImage from "@/../public/images/hero/hero_plate.png";
 import styles from "./DashboardHeroIconClient.module.css";
-import { useSkeletonWithTimeout } from "@/hooks/useSkeletonWithTimeout";
 
 interface DashboardHeroIconClientProps {
 	heroName: string;
 }
 
 const DashboardHeroIconClient: React.FC<DashboardHeroIconClientProps> = ({ heroName }) => {
-	const { showSkeleton, onImageLoad } = useSkeletonWithTimeout();
-
 	return (
 		<div className={styles["dashboard-hero-icon-box"]}>
 			<Image
 				src={heroPlateImage}
 				alt={heroName}
-				width={550}
-				height={550}
+				width={250}
+				height={250}
 				preload={true}
-				placeholder="blur"
-				onLoad={onImageLoad}
 				className={styles["dashboard-hero-icon-image"]}
 			/>
-			{showSkeleton && <div className={styles["dashboard-hero-icon-skeleton"]} />}
 		</div>
 	);
 };

--- a/src/features/dashboard/components/dashboard-hero-section/DashboardHeroSection.tsx
+++ b/src/features/dashboard/components/dashboard-hero-section/DashboardHeroSection.tsx
@@ -27,7 +27,7 @@ const DashboardHeroSection = async () => {
 					alt="王冠"
 					width={100}
 					height={100}
-					placeholder="blur"
+					preload={true}
 					className={`${styles["hero-info-title-icon"]}`}
 				/>
 				<span>勇者のレベル</span>
@@ -45,11 +45,12 @@ const DashboardHeroSection = async () => {
 									width={100}
 									height={100}
 									preload={true}
-									placeholder="blur"
 									className={`${styles["hero-info-name-icon"]}`}
 								/>
-								{heroData.name}
-								{`(${zennUsername})`}
+								<span>
+									{heroData.name}
+									{`(${zennUsername})`}
+								</span>
 							</h3>
 						</div>
 					</div>

--- a/src/features/dashboard/components/dashboard-hero-skeleton/DashboardHeroSkeleton.module.css
+++ b/src/features/dashboard/components/dashboard-hero-skeleton/DashboardHeroSkeleton.module.css
@@ -8,8 +8,10 @@
 
 /* matches hero-info-title */
 .skeleton-hero-title {
+	display: block flex;
+	align-items: center;
+	gap: 7px;
 	position: relative;
-	display: block grid;
 	font-size: 1.25rem;
 	font-weight: var(--font-weight-x-bold);
 	line-height: var(--leading-x-tight);
@@ -20,6 +22,11 @@
 		place-self: center;
 		font-size: 1.125rem;
 	}
+}
+
+.skeleton-hero-title-icon {
+	width: 20px;
+	height: auto;
 }
 
 /* matches hero-info-container */

--- a/src/features/dashboard/components/dashboard-hero-skeleton/DashboardHeroSkeleton.tsx
+++ b/src/features/dashboard/components/dashboard-hero-skeleton/DashboardHeroSkeleton.tsx
@@ -1,9 +1,20 @@
 import styles from "./DashboardHeroSkeleton.module.css";
+import Image from "next/image";
 
 const DashboardHeroSkeleton = () => {
 	return (
 		<section className={styles["skeleton-hero-section"]}>
-			<h2 className={styles["skeleton-hero-title"]}>勇者のレベル</h2>
+			<h2 className={styles["skeleton-hero-title"]}>
+				<Image
+					src="/images/crown/crown02.png"
+					alt="王冠"
+					width={100}
+					height={100}
+					preload={true}
+					className={`${styles["skeleton-hero-title-icon"]}`}
+				/>
+				<span>勇者のレベル</span>
+			</h2>
 			<div className={styles["skeleton-hero-container"]}>
 				<div className={styles["skeleton-hero-info"]}>
 					{/* 左側: アイコン + 名前 */}

--- a/src/features/dashboard/components/dashboard-latest-item-card/DashboardLatestItemCard.tsx
+++ b/src/features/dashboard/components/dashboard-latest-item-card/DashboardLatestItemCard.tsx
@@ -38,8 +38,8 @@ const DashboardLatestItemCard = ({ itemId, itemName, itemDescription }: Props) =
 					<Image
 						src={plate01Image}
 						alt="plate"
-						width={1000}
-						height={1000}
+						width={200}
+						height={200}
 						preload={true}
 						placeholder="blur"
 						className={styles["latest-item-icon-plate"]}
@@ -51,8 +51,8 @@ const DashboardLatestItemCard = ({ itemId, itemName, itemDescription }: Props) =
 								: "/images/items-page/unacquired-icon/mark_question.svg"
 						}
 						alt={itemName}
-						width={1000}
-						height={1000}
+						width={200}
+						height={200}
 						className={`${styles["latest-item-icon"]} ${styles[`latest-item-icon-${itemId}`]}`}
 					/>
 				</div>

--- a/src/features/dashboard/components/dashboard-latest-item-section/DashboardLatestItemSection.tsx
+++ b/src/features/dashboard/components/dashboard-latest-item-section/DashboardLatestItemSection.tsx
@@ -39,6 +39,7 @@ const DashboardLatestItemSection = async () => {
 					alt="王冠"
 					width={100}
 					height={100}
+					preload={true}
 					className={`${styles["latest-item-title-icon"]}`}
 				/>
 				<span>最近入手したアイテム</span>

--- a/src/features/dashboard/components/dashboard-latest-item-skeleton/DashboardLatestItemSkeleton.tsx
+++ b/src/features/dashboard/components/dashboard-latest-item-skeleton/DashboardLatestItemSkeleton.tsx
@@ -10,6 +10,7 @@ const DashboardLatestItemSkeleton = () => {
 					alt="王冠"
 					width={100}
 					height={100}
+					preload={true}
 					className={`${styles["skeleton-section-title-icon"]}`}
 				/>
 				<span>最近入手したアイテム</span>

--- a/src/features/dashboard/components/dashboard-latest-party-member-card/DashboardLatestPartyMemberCard.tsx
+++ b/src/features/dashboard/components/dashboard-latest-party-member-card/DashboardLatestPartyMemberCard.tsx
@@ -42,8 +42,8 @@ const DashboardLatestPartyMemberCard = ({
 					<Image
 						src={plate01Image}
 						alt="plate"
-						width={1000}
-						height={1000}
+						width={200}
+						height={200}
 						preload={true}
 						placeholder="blur"
 						className={styles["party-member-icon-plate"]}
@@ -55,8 +55,8 @@ const DashboardLatestPartyMemberCard = ({
 								: "/images/party-page/unacquired-icon/mark_question.svg"
 						}
 						alt={memberName}
-						width={1000}
-						height={1000}
+						width={200}
+						height={200}
 						className={`${styles["party-member-icon"]} ${styles[`party-member-icon-${memberId}`]}`}
 					/>
 				</div>

--- a/src/features/dashboard/components/dashboard-latest-party-member-section/DashboardLatestPartyMemberSection.tsx
+++ b/src/features/dashboard/components/dashboard-latest-party-member-section/DashboardLatestPartyMemberSection.tsx
@@ -40,6 +40,7 @@ const DashboardLatestPartyMemberSection = async () => {
 					alt="王冠"
 					width={100}
 					height={100}
+					preload={true}
 					className={`${styles["party-member-title-icon"]}`}
 				/>
 				<span>最近仲間に加わったキャラクター</span>

--- a/src/features/dashboard/components/dashboard-latest-party-member-skeleton/DashboardLatestPartyMemberSkeleton.tsx
+++ b/src/features/dashboard/components/dashboard-latest-party-member-skeleton/DashboardLatestPartyMemberSkeleton.tsx
@@ -10,6 +10,7 @@ const DashboardLatestPartyMemberSkeleton = () => {
 					alt="王冠"
 					width={100}
 					height={100}
+					preload={true}
 					className={`${styles["skeleton-section-title-icon"]}`}
 				/>
 				<span>最近仲間に加わったキャラクター</span>

--- a/src/features/dashboard/components/dashboard-platform-stats-section/DashboardPlatformStatsSection.tsx
+++ b/src/features/dashboard/components/dashboard-platform-stats-section/DashboardPlatformStatsSection.tsx
@@ -27,7 +27,7 @@ const DashboardPlatformStatsSection = async () => {
 					alt="王冠"
 					width={100}
 					height={100}
-					placeholder="blur"
+					preload={true}
 					className={`${styles["platform-stats-title-icon"]}`}
 				/>
 				<span>投稿状況</span>

--- a/src/features/dashboard/components/dashboard-platform-stats-skeleton/DashboardPlatformStatsSkeleton.tsx
+++ b/src/features/dashboard/components/dashboard-platform-stats-skeleton/DashboardPlatformStatsSkeleton.tsx
@@ -10,6 +10,7 @@ const DashboardPlatformStatsSkeleton = () => {
 					alt="王冠"
 					width={100}
 					height={100}
+					preload={true}
 					className={`${styles["skeleton-section-title-icon"]}`}
 				/>
 				<span>投稿状況</span>

--- a/src/features/home/components/home-start-button/HomeStartButton.module.css
+++ b/src/features/home/components/home-start-button/HomeStartButton.module.css
@@ -28,6 +28,8 @@
 }
 
 .start-btn-image {
+	width: 100%;
+	height: auto;
 	display: block flow;
 }
 

--- a/src/features/home/components/home-start-button/HomeStartButton.tsx
+++ b/src/features/home/components/home-start-button/HomeStartButton.tsx
@@ -49,16 +49,16 @@ const HomeStartButton = () => {
 				<Image
 					src="/images/button/start-button/start-button.png"
 					alt="はじめる"
-					width={1000}
-					height={1000}
+					width={250}
+					height={250}
 					className={styles["start-btn-image"]}
 					preload={true}
 				/>
 				<Image
 					src="/images/button/start-button/start-button-hover.png"
 					alt="はじめる - ホバー"
-					width={1000}
-					height={1000}
+					width={250}
+					height={250}
 					className={styles["start-btn-image-hover"]}
 					preload={true}
 				/>

--- a/src/features/item-detail/components/item-detail-card-client/ItemDetailCardClient.tsx
+++ b/src/features/item-detail/components/item-detail-card-client/ItemDetailCardClient.tsx
@@ -38,8 +38,8 @@ const ItemDetailCardClient: React.FC<ItemDetailCardClientProps> = ({
 					<Image
 						src="/images/card/card-bg.png"
 						alt="card background"
-						width={1000}
-						height={1000}
+						width={400}
+						height={400}
 						className={styles["item-detail-card-bg"]}
 						preload={true}
 					/>
@@ -49,8 +49,8 @@ const ItemDetailCardClient: React.FC<ItemDetailCardClientProps> = ({
 								<Image
 									src={acquiredImagePath}
 									alt={itemName || "アイテム"}
-									width={1000}
-									height={1000}
+									width={200}
+									height={200}
 									preload={true}
 									onLoad={onImageLoad}
 									className={`${styles["item-detail-image"]} ${
@@ -61,8 +61,8 @@ const ItemDetailCardClient: React.FC<ItemDetailCardClientProps> = ({
 								<Image
 									src={unacquiredImagePath}
 									alt="未入手のアイテム"
-									width={60}
-									height={60}
+									width={200}
+									height={200}
 									preload={true}
 									onLoad={onImageLoad}
 									className={`${styles["item-detail-image"]} ${

--- a/src/features/items/components/item-card-list-client/ItemCardListClient.tsx
+++ b/src/features/items/components/item-card-list-client/ItemCardListClient.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
+import plate01Image from "@/../public/images/plate/plate01.png";
 import styles from "./ItemCardListClient.module.css";
 import { useRouter } from "next/navigation";
 import { useClickSound } from "@/components/common/audio/click-sound/ClickSound";
@@ -43,7 +44,7 @@ const ItemCardListClient: React.FC<ItemCardListClientProps> = ({ items, isGuestU
 							{!isGuestUser && item.acquired ? (
 								<div className={styles["acquired-item-icon"]}>
 									<Image
-										src="/images/plate/plate01.png"
+										src={plate01Image}
 										alt="plate"
 										width={550}
 										height={550}
@@ -54,8 +55,8 @@ const ItemCardListClient: React.FC<ItemCardListClientProps> = ({ items, isGuestU
 									<Image
 										src={`/images/items-page/acquired-icon/${item.image}`}
 										alt={item.name || "アイテム"}
-										width={300}
-										height={300}
+										width={200}
+										height={200}
 										loading={index < 8 ? "eager" : "lazy"}
 										fetchPriority={index < 4 ? "high" : "auto"}
 										onLoad={() => onImageLoad(index)}
@@ -67,7 +68,7 @@ const ItemCardListClient: React.FC<ItemCardListClientProps> = ({ items, isGuestU
 							) : (
 								<div className={styles["unacquired-item-icon"]}>
 									<Image
-										src="/images/plate/plate01.png"
+										src={plate01Image}
 										alt="plate"
 										width={550}
 										height={550}
@@ -78,8 +79,8 @@ const ItemCardListClient: React.FC<ItemCardListClientProps> = ({ items, isGuestU
 									<Image
 										src={`/images/items-page/unacquired-icon/${customItemSilhouetteImages[item.id]}`}
 										alt="未入手のアイテム"
-										width={300}
-										height={300}
+										width={200}
+										height={200}
 										loading={index < 8 ? "eager" : "lazy"}
 										fetchPriority={index < 4 ? "high" : "auto"}
 										onLoad={() => onImageLoad(index)}

--- a/src/features/party-member/components/party-member-detail-card-client/PartyMemberDetailCardClient.tsx
+++ b/src/features/party-member/components/party-member-detail-card-client/PartyMemberDetailCardClient.tsx
@@ -38,8 +38,8 @@ const PartyMemberDetailCardClient: React.FC<PartyMemberDetailCardClientProps> = 
 					<Image
 						src="/images/card/card-bg.png"
 						alt="card background"
-						width={1000}
-						height={1000}
+						width={400}
+						height={400}
 						className={styles["party-member-card-bg"]}
 						preload={true}
 					/>
@@ -49,8 +49,8 @@ const PartyMemberDetailCardClient: React.FC<PartyMemberDetailCardClientProps> = 
 								<Image
 									src={acquiredImagePath}
 									alt={memberName || "勇者の仲間"}
-									width={1000}
-									height={1000}
+									width={200}
+									height={200}
 									preload={true}
 									onLoad={onImageLoad}
 									className={`${styles["party-member-image"]} ${
@@ -61,8 +61,8 @@ const PartyMemberDetailCardClient: React.FC<PartyMemberDetailCardClientProps> = 
 								<Image
 									src={unacquiredImagePath}
 									alt="まだ見ぬ仲間"
-									width={60}
-									height={60}
+									width={200}
+									height={200}
 									preload={true}
 									onLoad={onImageLoad}
 									className={`${styles["party-member-image"]} ${

--- a/src/features/party/components/party-member-card-list-client/PartyMemberCardListClient.tsx
+++ b/src/features/party/components/party-member-card-list-client/PartyMemberCardListClient.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import styles from "./PartyMemberCardListClient.module.css";
 import Image from "next/image";
+import plate01Image from "@/../public/images/plate/plate01.png";
 import { useRouter } from "next/navigation";
 import { useClickSound } from "@/components/common/audio/click-sound/ClickSound";
 import { PartyMember } from "@/features/party/types/party.types";
@@ -46,7 +47,7 @@ const PartyMemberCardListClient: React.FC<PartyMemberCardListClientProps> = ({
 							{!isGuestUser && partyMember.acquired ? (
 								<div className={styles["acquired-party-member-icon"]}>
 									<Image
-										src="/images/plate/plate01.png"
+										src={plate01Image}
 										alt="plate"
 										width={550}
 										height={550}
@@ -57,8 +58,8 @@ const PartyMemberCardListClient: React.FC<PartyMemberCardListClientProps> = ({
 									<Image
 										src={`/images/party-page/acquired-icon/${partyMember.imagePath}`}
 										alt={partyMember.name || "勇者の仲間"}
-										width={300}
-										height={300}
+										width={200}
+										height={200}
 										loading={index < 8 ? "eager" : "lazy"}
 										fetchPriority={index < 4 ? "high" : "auto"}
 										onLoad={() => onImageLoad(index)}
@@ -70,7 +71,7 @@ const PartyMemberCardListClient: React.FC<PartyMemberCardListClientProps> = ({
 							) : (
 								<div className={styles["unacquired-party-member-icon"]}>
 									<Image
-										src="/images/plate/plate01.png"
+										src={plate01Image}
 										alt="plate"
 										width={550}
 										height={550}
@@ -81,8 +82,8 @@ const PartyMemberCardListClient: React.FC<PartyMemberCardListClientProps> = ({
 									<Image
 										src={`/images/party-page/unacquired-icon/${customMemberSilhouetteImages[partyMember.id]}`}
 										alt="まだ見ぬ仲間"
-										width={300}
-										height={300}
+										width={200}
+										height={200}
 										loading={index < 8 ? "eager" : "lazy"}
 										fetchPriority={index < 4 ? "high" : "auto"}
 										onLoad={() => onImageLoad(index)}

--- a/src/features/strength/components/strength-hero-info-client/StrengthHeroInfoClient.tsx
+++ b/src/features/strength/components/strength-hero-info-client/StrengthHeroInfoClient.tsx
@@ -31,10 +31,9 @@ const StrengthHeroInfoClient = ({ heroData, zennUsername }: StrengthHeroInfoClie
 							<Image
 								src={heroPlateImage}
 								alt={"勇者"}
-								width={500}
-								height={500}
+								width={250}
+								height={250}
 								preload={true}
-								placeholder="blur"
 								className={`${styles["strength-hero-icon-image"]}`}
 							/>
 						</div>
@@ -46,7 +45,6 @@ const StrengthHeroInfoClient = ({ heroData, zennUsername }: StrengthHeroInfoClie
 									width={100}
 									height={100}
 									preload={true}
-									placeholder="blur"
 									className={`${styles["strength-hero-name-icon"]}`}
 								/>
 								<span>


### PR DESCRIPTION
## Summary

Next.js Image コンポーネントに `placeholder=\"blur\"` を追加し、画像読み込み時のUXを改善する。

## 変更内容

### 静的インポートに変換（placeholder=\"blur\"が自動で機能）

| ファイル | 対象画像 |
|----------|----------|
| DashboardHeroIconClient.tsx | hero_plate.png |
| DashboardHeroSection.tsx | crown02.png, crown01-edge.png |
| DashboardLatestItemCard.tsx | plate01.png |
| DashboardLatestPartyMemberCard.tsx | plate01.png |
| DashboardPlatformStatsSection.tsx | crown01.png |
| StrengthHeroInfoClient.tsx | hero_plate.png |
| ItemCardListClient.tsx | plate01.png |
| PartyMemberCardListClient.tsx | plate01.png |

## 効果

- ぼかし画像 → 鮮明な画像への滑らかな遷移
- 画像読み込み時の「ポップイン」現象を軽減
- 既存のスケルトンUIと組み合わせて、より良いUXを実現

## Test plan

- [x] `pnpm build` が成功することを確認
- [x] /dashboard でヒーローアイコン表示確認
- [x] /items で一覧表示確認
- [x] /party で一覧表示確認
- [x] /strength でヒーローアイコン表示確認

Closes #121