### PR TITLE
refactor: useSkeletonWithTimeout フック抽出

### DIFF
--- a/src/features/about/components/about-guide-icon-client/AboutGuideIconClient.tsx
+++ b/src/features/about/components/about-guide-icon-client/AboutGuideIconClient.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import Image from "next/image";
 import styles from "./AboutGuideIconClient.module.css";
+import { useSkeletonWithTimeout } from "@/hooks/useSkeletonWithTimeout";
 
 interface AboutGuideIconClientProps {
 	iconSrc: string;
@@ -10,23 +10,7 @@ interface AboutGuideIconClientProps {
 }
 
 const AboutGuideIconClient: React.FC<AboutGuideIconClientProps> = ({ iconSrc, alt }) => {
-	const [showSkeleton, setShowSkeleton] = useState(true);
-	const [imageLoaded, setImageLoaded] = useState(false);
-
-	// 最大2.5秒でタイムアウト（UX観点で適切な上限）
-	useEffect(() => {
-		setImageLoaded(false);
-		setShowSkeleton(true);
-		const timer = setTimeout(() => setShowSkeleton(false), 2500);
-		return () => clearTimeout(timer);
-	}, [iconSrc]);
-
-	// 画像が読み込まれたら即座にスケルトンを非表示
-	useEffect(() => {
-		if (imageLoaded) {
-			setShowSkeleton(false);
-		}
-	}, [imageLoaded]);
+	const { showSkeleton, onImageLoad } = useSkeletonWithTimeout([iconSrc]);
 
 	return (
 		<div className={styles["about-guide-icon-wrapper"]}>
@@ -36,7 +20,7 @@ const AboutGuideIconClient: React.FC<AboutGuideIconClientProps> = ({ iconSrc, al
 				width={1000}
 				height={1000}
 				preload={true}
-				onLoad={() => setImageLoaded(true)}
+				onLoad={onImageLoad}
 				className={styles["about-guide-icon-image"]}
 			/>
 			{showSkeleton && <div className={styles["about-guide-icon-skeleton"]} />}

--- a/src/features/dashboard/components/dashboard-hero-icon-client/DashboardHeroIconClient.tsx
+++ b/src/features/dashboard/components/dashboard-hero-icon-client/DashboardHeroIconClient.tsx
@@ -1,29 +1,15 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import Image from "next/image";
 import styles from "./DashboardHeroIconClient.module.css";
+import { useSkeletonWithTimeout } from "@/hooks/useSkeletonWithTimeout";
 
 interface DashboardHeroIconClientProps {
 	heroName: string;
 }
 
 const DashboardHeroIconClient: React.FC<DashboardHeroIconClientProps> = ({ heroName }) => {
-	const [showSkeleton, setShowSkeleton] = useState(true);
-	const [imageLoaded, setImageLoaded] = useState(false);
-
-	// 最大2.5秒でタイムアウト（UX観点で適切な上限）
-	useEffect(() => {
-		const timer = setTimeout(() => setShowSkeleton(false), 2500);
-		return () => clearTimeout(timer);
-	}, []);
-
-	// 画像が読み込まれたら即座にスケルトンを非表示
-	useEffect(() => {
-		if (imageLoaded) {
-			setShowSkeleton(false);
-		}
-	}, [imageLoaded]);
+	const { showSkeleton, onImageLoad } = useSkeletonWithTimeout();
 
 	return (
 		<div className={styles["dashboard-hero-icon-box"]}>
@@ -33,7 +19,7 @@ const DashboardHeroIconClient: React.FC<DashboardHeroIconClientProps> = ({ heroN
 				width={550}
 				height={550}
 				preload={true}
-				onLoad={() => setImageLoaded(true)}
+				onLoad={onImageLoad}
 				className={styles["dashboard-hero-icon-image"]}
 			/>
 			{showSkeleton && <div className={styles["dashboard-hero-icon-skeleton"]} />}

--- a/src/features/item-detail/components/item-detail-card-client/ItemDetailCardClient.tsx
+++ b/src/features/item-detail/components/item-detail-card-client/ItemDetailCardClient.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import Image from "next/image";
 import styles from "./ItemDetailCardClient.module.css";
 import * as ItemDetail from "@/features/item-detail/components";
+import { useSkeletonWithTimeout } from "@/hooks/useSkeletonWithTimeout";
 
 interface ItemDetailCardClientProps {
 	itemId: number;
@@ -28,23 +28,7 @@ const ItemDetailCardClient: React.FC<ItemDetailCardClientProps> = ({
 	acquiredImagePath,
 	unacquiredImagePath,
 }) => {
-	const [showSkeleton, setShowSkeleton] = useState(true);
-	const [imageLoaded, setImageLoaded] = useState(false);
-
-	// 最大2.5秒でタイムアウト（UX観点で適切な上限）
-	useEffect(() => {
-		setImageLoaded(false);
-		setShowSkeleton(true);
-		const timer = setTimeout(() => setShowSkeleton(false), 2500);
-		return () => clearTimeout(timer);
-	}, [itemId, isAcquired, isGuestUser]);
-
-	// 画像が読み込まれたら即座にスケルトンを非表示
-	useEffect(() => {
-		if (imageLoaded) {
-			setShowSkeleton(false);
-		}
-	}, [imageLoaded]);
+	const { showSkeleton, onImageLoad } = useSkeletonWithTimeout([itemId, isAcquired, isGuestUser]);
 
 	return (
 		<div className={styles["item-detail-content"]}>
@@ -68,7 +52,7 @@ const ItemDetailCardClient: React.FC<ItemDetailCardClientProps> = ({
 									width={1000}
 									height={1000}
 									preload={true}
-									onLoad={() => setImageLoaded(true)}
+									onLoad={onImageLoad}
 									className={`${styles["item-detail-image"]} ${
 										styles[`item-detail-image-${itemId}`]
 									}`}
@@ -80,7 +64,7 @@ const ItemDetailCardClient: React.FC<ItemDetailCardClientProps> = ({
 									width={60}
 									height={60}
 									preload={true}
-									onLoad={() => setImageLoaded(true)}
+									onLoad={onImageLoad}
 									className={`${styles["item-detail-image"]} ${
 										styles[`item-detail-image-${itemId}`]
 									}`}

--- a/src/features/items/components/item-card-list-client/ItemCardListClient.tsx
+++ b/src/features/items/components/item-card-list-client/ItemCardListClient.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import styles from "./ItemCardListClient.module.css";
@@ -9,6 +8,7 @@ import { useClickSound } from "@/components/common/audio/click-sound/ClickSound"
 import { Item } from "@/features/items/types/items.types";
 import { customItemSilhouetteImages } from "@/features/items/data/itemsData";
 import ItemListSkeleton from "@/features/items/components/item-list-skeleton/ItemListSkeleton";
+import { useListSkeletonWithTimeout } from "@/hooks/useSkeletonWithTimeout";
 
 interface ItemCardListClientProps {
 	items: Item[];
@@ -22,36 +22,11 @@ const ItemCardListClient: React.FC<ItemCardListClientProps> = ({ items, isGuestU
 		volume: 0.5,
 		delay: 190,
 	});
-	const [isLoading, setIsLoading] = useState(true);
-	const [loadedImages, setLoadedImages] = useState<Set<number>>(new Set());
-
-	// 最大2.5秒でタイムアウト（UX観点で適切な上限）
-	useEffect(() => {
-		const MAX_WAIT_MS = 2500;
-		const timerId = setTimeout(() => {
-			setIsLoading(false);
-		}, MAX_WAIT_MS);
-		return () => clearTimeout(timerId);
-	}, []);
-
-	// ファーストビュー画像が全て読み込まれたら即座にスケルトンを非表示
-	useEffect(() => {
-		const FIRST_VIEW_COUNT = 8;
-		const totalFirstView = Math.min(items.length, FIRST_VIEW_COUNT);
-		if (loadedImages.size >= totalFirstView) {
-			setIsLoading(false);
-		}
-	}, [loadedImages, items.length]);
+	const { isLoading, onImageLoad } = useListSkeletonWithTimeout(items.length);
 
 	const handleNavigation = (e: React.MouseEvent<HTMLAnchorElement>, path: string) => {
 		e.preventDefault();
 		playClickSound(() => router.push(path));
-	};
-
-	const handleImageLoad = (index: number) => {
-		if (index < 8) {
-			setLoadedImages((prev) => new Set(prev).add(index));
-		}
 	};
 
 	return (
@@ -83,7 +58,7 @@ const ItemCardListClient: React.FC<ItemCardListClientProps> = ({ items, isGuestU
 										height={300}
 										loading={index < 8 ? "eager" : "lazy"}
 										fetchPriority={index < 4 ? "high" : "auto"}
-										onLoad={() => handleImageLoad(index)}
+										onLoad={() => onImageLoad(index)}
 										className={`${styles["acquired-item-icon-image"]} ${
 											styles[`acquired-item-icon-image-${item.id}`]
 										}`}
@@ -107,7 +82,7 @@ const ItemCardListClient: React.FC<ItemCardListClientProps> = ({ items, isGuestU
 										height={300}
 										loading={index < 8 ? "eager" : "lazy"}
 										fetchPriority={index < 4 ? "high" : "auto"}
-										onLoad={() => handleImageLoad(index)}
+										onLoad={() => onImageLoad(index)}
 										className={`${styles["unacquired-item-icon-image"]} ${
 											styles[`unacquired-item-icon-image-${item.id}`]
 										}`}

--- a/src/features/party-member/components/party-member-detail-card-client/PartyMemberDetailCardClient.tsx
+++ b/src/features/party-member/components/party-member-detail-card-client/PartyMemberDetailCardClient.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import Image from "next/image";
 import styles from "./PartyMemberDetailCardClient.module.css";
 import * as PartyMember from "@/features/party-member/components";
+import { useSkeletonWithTimeout } from "@/hooks/useSkeletonWithTimeout";
 
 interface PartyMemberDetailCardClientProps {
 	partyId: number;
@@ -28,23 +28,7 @@ const PartyMemberDetailCardClient: React.FC<PartyMemberDetailCardClientProps> = 
 	acquiredImagePath,
 	unacquiredImagePath,
 }) => {
-	const [showSkeleton, setShowSkeleton] = useState(true);
-	const [imageLoaded, setImageLoaded] = useState(false);
-
-	// 最大2.5秒でタイムアウト（UX観点で適切な上限）
-	useEffect(() => {
-		setImageLoaded(false);
-		setShowSkeleton(true);
-		const timer = setTimeout(() => setShowSkeleton(false), 2500);
-		return () => clearTimeout(timer);
-	}, [partyId, isAcquired, isGuestUser]);
-
-	// 画像が読み込まれたら即座にスケルトンを非表示
-	useEffect(() => {
-		if (imageLoaded) {
-			setShowSkeleton(false);
-		}
-	}, [imageLoaded]);
+	const { showSkeleton, onImageLoad } = useSkeletonWithTimeout([partyId, isAcquired, isGuestUser]);
 
 	return (
 		<div className={styles["party-member-content"]}>
@@ -68,7 +52,7 @@ const PartyMemberDetailCardClient: React.FC<PartyMemberDetailCardClientProps> = 
 									width={1000}
 									height={1000}
 									preload={true}
-									onLoad={() => setImageLoaded(true)}
+									onLoad={onImageLoad}
 									className={`${styles["party-member-image"]} ${
 										styles[`party-member-image-${partyId}`]
 									}`}
@@ -80,7 +64,7 @@ const PartyMemberDetailCardClient: React.FC<PartyMemberDetailCardClientProps> = 
 									width={60}
 									height={60}
 									preload={true}
-									onLoad={() => setImageLoaded(true)}
+									onLoad={onImageLoad}
 									className={`${styles["party-member-image"]} ${
 										styles[`party-member-image-${partyId}`]
 									}`}

--- a/src/features/party/components/party-member-card-list-client/PartyMemberCardListClient.tsx
+++ b/src/features/party/components/party-member-card-list-client/PartyMemberCardListClient.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import Link from "next/link";
 import styles from "./PartyMemberCardListClient.module.css";
 import Image from "next/image";
@@ -9,6 +8,7 @@ import { useClickSound } from "@/components/common/audio/click-sound/ClickSound"
 import { PartyMember } from "@/features/party/types/party.types";
 import { customMemberSilhouetteImages } from "@/features/party/data/partyMemberData";
 import PartyListSkeleton from "@/features/party/components/party-list-skeleton/PartyListSkeleton";
+import { useListSkeletonWithTimeout } from "@/hooks/useSkeletonWithTimeout";
 
 interface PartyMemberCardListClientProps {
 	members: PartyMember[];
@@ -25,36 +25,11 @@ const PartyMemberCardListClient: React.FC<PartyMemberCardListClientProps> = ({
 		volume: 0.5,
 		delay: 190,
 	});
-	const [isLoading, setIsLoading] = useState(true);
-	const [loadedImages, setLoadedImages] = useState<Set<number>>(new Set());
-
-	// 最大2.5秒でタイムアウト（UX観点で適切な上限）
-	useEffect(() => {
-		const MAX_WAIT_MS = 2500;
-		const timerId = setTimeout(() => {
-			setIsLoading(false);
-		}, MAX_WAIT_MS);
-		return () => clearTimeout(timerId);
-	}, []);
-
-	// ファーストビュー画像が全て読み込まれたら即座にスケルトンを非表示
-	useEffect(() => {
-		const FIRST_VIEW_COUNT = 8;
-		const totalFirstView = Math.min(members.length, FIRST_VIEW_COUNT);
-		if (loadedImages.size >= totalFirstView) {
-			setIsLoading(false);
-		}
-	}, [loadedImages, members.length]);
+	const { isLoading, onImageLoad } = useListSkeletonWithTimeout(members.length);
 
 	const handleNavigation = (e: React.MouseEvent<HTMLAnchorElement>, path: string) => {
 		e.preventDefault();
 		playClickSound(() => router.push(path));
-	};
-
-	const handleImageLoad = (index: number) => {
-		if (index < 8) {
-			setLoadedImages((prev) => new Set(prev).add(index));
-		}
 	};
 
 	return (
@@ -86,7 +61,7 @@ const PartyMemberCardListClient: React.FC<PartyMemberCardListClientProps> = ({
 										height={300}
 										loading={index < 8 ? "eager" : "lazy"}
 										fetchPriority={index < 4 ? "high" : "auto"}
-										onLoad={() => handleImageLoad(index)}
+										onLoad={() => onImageLoad(index)}
 										className={`${styles["acquired-party-member-icon-image"]} ${
 											styles[`acquired-party-member-icon-image-${partyMember.id}`]
 										}`}
@@ -110,7 +85,7 @@ const PartyMemberCardListClient: React.FC<PartyMemberCardListClientProps> = ({
 										height={300}
 										loading={index < 8 ? "eager" : "lazy"}
 										fetchPriority={index < 4 ? "high" : "auto"}
-										onLoad={() => handleImageLoad(index)}
+										onLoad={() => onImageLoad(index)}
 										className={`${styles["unacquired-party-member-icon-image"]} ${
 											styles[`unacquired-party-member-icon-image-${partyMember.id}`]
 										}`}

--- a/src/hooks/useSkeletonWithTimeout.ts
+++ b/src/hooks/useSkeletonWithTimeout.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState, useEffect, useCallback, DependencyList } from "react";
+
+/**
+ * 単一画像のスケルトンUI管理フック
+ *
+ * 画像のロード状態とタイムアウトを管理し、スケルトン表示の制御を行う。
+ * - 画像がロードされたら即座にスケルトンを非表示
+ * - 最大2.5秒でタイムアウトしてスケルトンを非表示
+ *
+ * @param deps - 依存配列（画像パスの変更時などにリセット）
+ * @param timeout - タイムアウト時間（ミリ秒）、デフォルト2500ms
+ * @returns showSkeleton - スケルトン表示フラグ
+ * @returns onImageLoad - 画像のonLoadに渡すコールバック
+ */
+export function useSkeletonWithTimeout(deps: DependencyList = [], timeout = 2500) {
+	const [showSkeleton, setShowSkeleton] = useState(true);
+	const [imageLoaded, setImageLoaded] = useState(false);
+
+	// 依存配列が変更されたらリセット
+	// Note: 依存配列変更時の状態リセットとタイマーセットのため、useEffect内でのsetStateは適切
+	useEffect(() => {
+		setShowSkeleton(true);
+		setImageLoaded(false);
+		const timer = setTimeout(() => setShowSkeleton(false), timeout);
+		return () => clearTimeout(timer);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, deps);
+
+	// 画像がロードされたら即座にスケルトンを非表示
+	// Note: 外部状態（画像ロード）との同期のため、useEffect内でのsetStateは適切
+	useEffect(() => {
+		if (imageLoaded) {
+			setShowSkeleton(false);
+		}
+	}, [imageLoaded]);
+
+	const onImageLoad = useCallback(() => {
+		setImageLoaded(true);
+	}, []);
+
+	return { showSkeleton, onImageLoad };
+}
+
+/**
+ * 複数画像リストのスケルトンUI管理フック
+ *
+ * リスト内の画像のロード状態とタイムアウトを管理し、スケルトン表示の制御を行う。
+ * - ファーストビュー画像が全てロードされたら即座にスケルトンを非表示
+ * - 最大2.5秒でタイムアウトしてスケルトンを非表示
+ *
+ * @param itemCount - リスト内のアイテム総数
+ * @param firstViewCount - ファーストビューに表示される画像数、デフォルト8
+ * @param timeout - タイムアウト時間（ミリ秒）、デフォルト2500ms
+ * @returns isLoading - ローディング状態フラグ
+ * @returns onImageLoad - 画像のonLoadに渡すコールバック（indexを引数に取る）
+ */
+export function useListSkeletonWithTimeout(itemCount: number, firstViewCount = 8, timeout = 2500) {
+	const [isLoading, setIsLoading] = useState(true);
+	const [loadedImages, setLoadedImages] = useState<Set<number>>(new Set());
+
+	// タイムアウト処理
+	useEffect(() => {
+		const timer = setTimeout(() => setIsLoading(false), timeout);
+		return () => clearTimeout(timer);
+	}, [timeout]);
+
+	// ファーストビュー画像が全てロードされたらスケルトンを非表示
+	// Note: 外部状態（画像ロード）との同期のため、useEffect内でのsetStateは適切
+	useEffect(() => {
+		const totalFirstView = Math.min(itemCount, firstViewCount);
+		if (loadedImages.size >= totalFirstView) {
+			setIsLoading(false);
+		}
+	}, [loadedImages, itemCount, firstViewCount]);
+
+	const onImageLoad = useCallback(
+		(index: number) => {
+			if (index < firstViewCount) {
+				setLoadedImages((prev) => new Set(prev).add(index));
+			}
+		},
+		[firstViewCount]
+	);
+
+	return { isLoading, onImageLoad };
+}


### PR DESCRIPTION
## Summary

スケルトンUI管理ロジックを6つのコンポーネントから共通フックに抽出しました。

### 変更内容

- **新規フック作成**: `src/hooks/useSkeletonWithTimeout.ts`
  - `useSkeletonWithTimeout`: 単一画像用（依存配列でリセット対応）
  - `useListSkeletonWithTimeout`: リスト画像用（ファーストビュー閾値対応）

- **対象コンポーネント（6ファイル）**:
  - DashboardHeroIconClient
  - AboutGuideIconClient
  - ItemDetailCardClient
  - PartyMemberDetailCardClient
  - PartyMemberCardListClient
  - ItemCardListClient

### 効果

- 重複コードの削減（134行 → 110行、24行削減）
- スケルトンUI管理ロジックの一元化
- 今後の保守性向上

## Test plan

- [x] Dashboard ページでヒーローアイコンのスケルトン表示確認
- [x] アイテム/仲間一覧ページでカード表示確認
- [x] アイテム/仲間詳細ページでカード表示確認
- [x] About ページでガイドアイコン表示確認

Closes #132