### PR TITLE
refactor: useZennConnectionStatus フック抽出

### DIFF
--- a/src/components/common/adventure-start-link/AdventureStartLink.tsx
+++ b/src/components/common/adventure-start-link/AdventureStartLink.tsx
@@ -1,34 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import styles from "./AdventureStartLink.module.css";
 import Link from "next/link";
 import Image from "next/image";
 import { useClickSound } from "@/components/common/audio/click-sound/ClickSound";
-import { useUser } from "@clerk/nextjs";
-import { UserInfo } from "@/features/connection/types";
+import { useZennConnectionStatus } from "@/hooks/useZennConnectionStatus";
 
 const AdventureStartLink = () => {
-	const { user, isLoaded } = useUser();
-	const [targetPath, setTargetPath] = useState<string>("/connection");
-
-	useEffect(() => {
-		const decidePath = async () => {
-			if (!isLoaded || !user) return;
-			try {
-				const res = await fetch("/api/user", { cache: "no-store" });
-				const data: { success: boolean; user?: UserInfo } = await res.json();
-				if (data.success && data.user?.zennUsername) {
-					setTargetPath("/dashboard");
-				}
-			} catch {
-				// ignore error and keep default
-			}
-		};
-		decidePath();
-		// user?.id only - using full user object causes unnecessary re-renders
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [isLoaded, user?.id]);
+	const { isZennConnected } = useZennConnectionStatus();
+	const targetPath = isZennConnected ? "/dashboard" : "/connection";
 
 	const { playClickSound } = useClickSound({
 		soundPath: "/audio/click-sound_decision.mp3",

--- a/src/features/home/components/home-start-button/HomeStartButton.tsx
+++ b/src/features/home/components/home-start-button/HomeStartButton.tsx
@@ -2,10 +2,9 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState, useEffect } from "react";
-import { useUser } from "@clerk/nextjs";
 import { useClickSound } from "@/components/common/audio/click-sound/ClickSound";
 import { useAudio } from "@/contexts/AudioContext";
+import { useZennConnectionStatus } from "@/hooks/useZennConnectionStatus";
 import styles from "./HomeStartButton.module.css";
 import Image from "next/image";
 import { motion } from "motion/react";
@@ -13,8 +12,7 @@ import { useHomeAnimation } from "@/features/home/contexts/HomeAnimationContext"
 
 const HomeStartButton = () => {
 	const router = useRouter();
-	const { user, isLoaded } = useUser();
-	const [isZennConnected, setIsZennConnected] = useState(false);
+	const { isZennConnected } = useZennConnectionStatus();
 	const { isMuted } = useAudio();
 	const { isImageVisible, isFirstVisit } = useHomeAnimation();
 
@@ -22,25 +20,6 @@ const HomeStartButton = () => {
 		soundPath: "/audio/start-sound.mp3",
 		volume: 1,
 	});
-
-	useEffect(() => {
-		if (isLoaded && user) {
-			const fetchUserStatus = async () => {
-				try {
-					const response = await fetch("/api/user");
-					if (response.ok) {
-						const data = await response.json();
-						if (data.success && data.user && data.user.zennUsername) {
-							setIsZennConnected(true);
-						}
-					}
-				} catch (error) {
-					console.error("Failed to fetch user status:", error);
-				}
-			};
-			fetchUserStatus();
-		}
-	}, [isLoaded, user]);
 
 	const destination = isZennConnected ? "/connection" : "/about";
 

--- a/src/features/item-detail/components/item-dynamic-head/ItemDynamicHead.tsx
+++ b/src/features/item-detail/components/item-dynamic-head/ItemDynamicHead.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useUser } from "@clerk/nextjs";
 import { useHero } from "@/contexts/HeroContext";
+import { useZennConnectionStatus } from "@/hooks/useZennConnectionStatus";
 import {
 	isAcquiredByHeroLevel,
 	customItemNames,
@@ -21,48 +22,7 @@ interface ItemDynamicHeadProps {
 const ItemDynamicHead: React.FC<ItemDynamicHeadProps> = ({ itemId }) => {
 	const { user, isLoaded } = useUser();
 	const { heroData, isLoading } = useHero();
-	const [userZennInfo, setUserZennInfo] = useState<{
-		zennUsername?: string;
-	} | null>(null);
-	const [isZennInfoLoaded, setIsZennInfoLoaded] = useState(false);
-
-	// ユーザーのZenn連携情報を取得
-	useEffect(() => {
-		const fetchUserZennInfo = async () => {
-			if (!isLoaded) {
-				setIsZennInfoLoaded(false);
-				return;
-			}
-
-			if (!user) {
-				setUserZennInfo(null);
-				setIsZennInfoLoaded(true);
-				return;
-			}
-
-			setIsZennInfoLoaded(false);
-
-			try {
-				const userRes = await fetch("/api/user");
-				const userData = await userRes.json();
-
-				if (userData.success) {
-					setUserZennInfo(userData.user);
-				} else {
-					setUserZennInfo(null);
-				}
-			} catch (err) {
-				console.error("ユーザー情報取得エラー:", err);
-				setUserZennInfo(null);
-			} finally {
-				setIsZennInfoLoaded(true);
-			}
-		};
-
-		fetchUserZennInfo();
-		// user?.id only - using full user object causes unnecessary re-renders
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [isLoaded, user?.id]);
+	const { zennUsername, isLoaded: isZennInfoLoaded } = useZennConnectionStatus();
 
 	useEffect(() => {
 		// ロード中は何もしない
@@ -85,7 +45,7 @@ const ItemDynamicHead: React.FC<ItemDynamicHeadProps> = ({ itemId }) => {
 		const twitterImageAltMeta = document.querySelector('meta[name="twitter:image:alt"]');
 
 		// ゲストユーザーまたはZenn未連携ユーザーの場合はゲスト用メタデータを表示
-		const isGuestUser = !user || !userZennInfo?.zennUsername;
+		const isGuestUser = !user || !zennUsername;
 
 		if (isGuestUser) {
 			const guestTitle = "未入手のアイテム";
@@ -172,7 +132,7 @@ const ItemDynamicHead: React.FC<ItemDynamicHeadProps> = ({ itemId }) => {
 				twitterImageMeta.setAttribute("content", `${window.location.origin}${unacquiredImageUrl}`);
 			if (twitterImageAltMeta) twitterImageAltMeta.setAttribute("content", unacquiredTitle);
 		}
-	}, [itemId, heroData.level, isLoading, user, isLoaded, userZennInfo, isZennInfoLoaded]);
+	}, [itemId, heroData.level, isLoading, user, isLoaded, zennUsername, isZennInfoLoaded]);
 
 	return null; // 何もレンダリングしない
 };

--- a/src/features/party-member/components/party-member-dynamic-head/PartyMemberDynamicHead.tsx
+++ b/src/features/party-member/components/party-member-dynamic-head/PartyMemberDynamicHead.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useUser } from "@clerk/nextjs";
 import { useHero } from "@/contexts/HeroContext";
+import { useZennConnectionStatus } from "@/hooks/useZennConnectionStatus";
 import {
 	isAcquiredByHeroLevel,
 	customMemberNames,
@@ -21,48 +22,7 @@ interface PartyMemberDynamicHeadProps {
 const PartyMemberDynamicHead: React.FC<PartyMemberDynamicHeadProps> = ({ partyId }) => {
 	const { user, isLoaded } = useUser();
 	const { heroData, isLoading } = useHero();
-	const [userZennInfo, setUserZennInfo] = useState<{
-		zennUsername?: string;
-	} | null>(null);
-	const [isZennInfoLoaded, setIsZennInfoLoaded] = useState(false);
-
-	// ユーザーのZenn連携情報を取得
-	useEffect(() => {
-		const fetchUserZennInfo = async () => {
-			if (!isLoaded) {
-				setIsZennInfoLoaded(false);
-				return;
-			}
-
-			if (!user) {
-				setUserZennInfo(null);
-				setIsZennInfoLoaded(true);
-				return;
-			}
-
-			setIsZennInfoLoaded(false);
-
-			try {
-				const userRes = await fetch("/api/user");
-				const userData = await userRes.json();
-
-				if (userData.success) {
-					setUserZennInfo(userData.user);
-				} else {
-					setUserZennInfo(null);
-				}
-			} catch (err) {
-				console.error("ユーザー情報取得エラー:", err);
-				setUserZennInfo(null);
-			} finally {
-				setIsZennInfoLoaded(true);
-			}
-		};
-
-		fetchUserZennInfo();
-		// user?.id only - using full user object causes unnecessary re-renders
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [isLoaded, user?.id]);
+	const { zennUsername, isLoaded: isZennInfoLoaded } = useZennConnectionStatus();
 
 	useEffect(() => {
 		// ロード中は何もしない
@@ -85,7 +45,7 @@ const PartyMemberDynamicHead: React.FC<PartyMemberDynamicHeadProps> = ({ partyId
 		const twitterImageAltMeta = document.querySelector('meta[name="twitter:image:alt"]');
 
 		// ゲストユーザーまたはZenn未連携ユーザーの場合はゲスト用メタデータを表示
-		const isGuestUser = !user || !userZennInfo?.zennUsername;
+		const isGuestUser = !user || !zennUsername;
 
 		if (isGuestUser) {
 			const guestTitle = "まだ見ぬ仲間";
@@ -172,7 +132,7 @@ const PartyMemberDynamicHead: React.FC<PartyMemberDynamicHeadProps> = ({ partyId
 				twitterImageMeta.setAttribute("content", `${window.location.origin}${unacquiredImageUrl}`);
 			if (twitterImageAltMeta) twitterImageAltMeta.setAttribute("content", unacquiredTitle);
 		}
-	}, [partyId, heroData.level, isLoading, user, isLoaded, userZennInfo, isZennInfoLoaded]);
+	}, [partyId, heroData.level, isLoading, user, isLoaded, zennUsername, isZennInfoLoaded]);
 
 	return null; // 何もレンダリングしない
 };

--- a/src/hooks/useZennConnectionStatus.ts
+++ b/src/hooks/useZennConnectionStatus.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useUser } from "@clerk/nextjs";
+
+interface UseZennConnectionStatusResult {
+	/** Zenn連携済みかどうか（シンプルなチェック用） */
+	isZennConnected: boolean;
+	/** ZennユーザーID（詳細情報が必要な場合用） */
+	zennUsername: string | null;
+	/** ローディング完了フラグ */
+	isLoaded: boolean;
+}
+
+/**
+ * Zenn連携状態を取得するフック
+ *
+ * ユーザーのZenn連携状態を/api/userから取得し、状態を管理する。
+ * - 未ログイン: isZennConnected=false, zennUsername=null, isLoaded=true
+ * - ログイン済み・Zenn未連携: isZennConnected=false, zennUsername=null, isLoaded=true
+ * - ログイン済み・Zenn連携済み: isZennConnected=true, zennUsername=<username>, isLoaded=true
+ *
+ * @returns Zenn連携状態
+ */
+export function useZennConnectionStatus(): UseZennConnectionStatusResult {
+	const { user, isLoaded: isUserLoaded } = useUser();
+	const [zennUsername, setZennUsername] = useState<string | null>(null);
+	const [isLoaded, setIsLoaded] = useState(false);
+
+	useEffect(() => {
+		// Clerkのユーザー情報がまだ読み込まれていない場合は待機
+		if (!isUserLoaded) {
+			setIsLoaded(false);
+			return;
+		}
+
+		// 未ログインの場合
+		if (!user) {
+			setZennUsername(null);
+			setIsLoaded(true);
+			return;
+		}
+
+		// ログイン済みの場合、Zenn連携状態を取得
+		let aborted = false;
+
+		const fetchZennStatus = async () => {
+			setIsLoaded(false);
+
+			try {
+				const response = await fetch("/api/user");
+				if (aborted) return;
+
+				if (response.ok) {
+					const data = await response.json();
+					if (data.success && data.user?.zennUsername) {
+						setZennUsername(data.user.zennUsername);
+					} else {
+						setZennUsername(null);
+					}
+				} else {
+					setZennUsername(null);
+				}
+			} catch (error) {
+				if (!aborted) {
+					console.error("Zenn連携状態の取得エラー:", error);
+					setZennUsername(null);
+				}
+			} finally {
+				if (!aborted) {
+					setIsLoaded(true);
+				}
+			}
+		};
+
+		fetchZennStatus();
+
+		return () => {
+			aborted = true;
+		};
+		// user?.id only - using full user object causes unnecessary re-renders
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [isUserLoaded, user?.id]);
+
+	return {
+		isZennConnected: zennUsername !== null,
+		zennUsername,
+		isLoaded,
+	};
+}


### PR DESCRIPTION
## Summary

Zenn連携状態取得ロジックを4つのコンポーネントから共通フックに抽出しました。

### 変更内容

- **新規フック作成**: `src/hooks/useZennConnectionStatus.ts`
  - `isZennConnected`: Zenn連携済みかどうか（boolean）
  - `zennUsername`: ZennユーザーID（string | null）
  - `isLoaded`: ローディング完了フラグ
  - 非同期処理のクリーンアップ対応（アンマウント時のsetState防止）

- **対象コンポーネント（4ファイル）**:
  - HomeStartButton（シンプルパターン: isZennConnected のみ使用）
  - AdventureStartLink（シンプルパターン: isZennConnected のみ使用）
  - ItemDynamicHead（詳細パターン: zennUsername + isLoaded 使用）
  - PartyMemberDynamicHead（詳細パターン: zennUsername + isLoaded 使用）

### 効果

- 重複コードの削減（136行 → 105行、31行削減）
- Zenn連携状態取得ロジックの一元化
- 今後の保守性向上

## Test plan

- [x] ログイン状態でホームページのスタートボタン遷移先確認
- [x] About ページの「冒険をはじめる」リンク遷移先確認
- [x] アイテム詳細ページのタイトル表示確認
- [x] 仲間詳細ページのタイトル表示確認

Closes #133