### PR TITLE
refactor: HomeStartButtonのZenn連携チェックをRSC化

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,9 @@
 import dynamic from "next/dynamic";
+import { Suspense } from "react";
 import styles from "./Home.module.css";
 import * as Home from "@/features/home/components";
 import * as Hero from "@/features/hero/components";
+import { getUser } from "@/features/user/_lib/fetcher";
 
 // Motion使用コンポーネントを動的インポート（Client Bundleを最小化）
 const HomeAnimatedTitle = dynamic(
@@ -10,6 +12,17 @@ const HomeAnimatedTitle = dynamic(
 const HomeAnimatedCrown = dynamic(
 	() => import("@/features/home/components/home-animated-crown/HomeAnimatedCrown")
 );
+
+/**
+ * スタートボタンをラップするServer Component
+ * getUser()でZenn連携状態を取得し、propsで渡す
+ */
+async function HomeStartButtonWrapper() {
+	const user = await getUser();
+	const isZennConnected = user?.zennUsername !== null && user?.zennUsername !== undefined;
+
+	return <Home.HomeStartButton isZennConnected={isZennConnected} />;
+}
 
 export default function HomePage() {
 	return (
@@ -20,7 +33,9 @@ export default function HomePage() {
 					<HomeAnimatedCrown />
 				</div>
 				<HomeAnimatedTitle />
-				<Home.HomeStartButton />
+				<Suspense fallback={null}>
+					<HomeStartButtonWrapper />
+				</Suspense>
 			</div>
 		</main>
 	);

--- a/src/features/home/components/home-start-button/HomeStartButton.tsx
+++ b/src/features/home/components/home-start-button/HomeStartButton.tsx
@@ -4,15 +4,18 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useClickSound } from "@/components/common/audio/click-sound/ClickSound";
 import { useAudio } from "@/contexts/AudioContext";
-import { useZennConnectionStatus } from "@/hooks/useZennConnectionStatus";
 import styles from "./HomeStartButton.module.css";
 import Image from "next/image";
 import { motion } from "motion/react";
 import { useHomeAnimation } from "@/features/home/contexts/HomeAnimationContext";
 
-const HomeStartButton = () => {
+interface HomeStartButtonProps {
+	/** Zenn連携済みかどうか（サーバーサイドで取得） */
+	isZennConnected: boolean;
+}
+
+const HomeStartButton = ({ isZennConnected }: HomeStartButtonProps) => {
 	const router = useRouter();
-	const { isZennConnected } = useZennConnectionStatus();
 	const { isMuted } = useAudio();
 	const { isImageVisible, isFirstVisit } = useHomeAnimation();
 


### PR DESCRIPTION
## Summary

- HomeStartButtonのZenn連携状態チェックをクライアントサイド（useZennConnectionStatusフック）からサーバーサイド（getUser()）に移行
- page.tsxにHomeStartButtonWrapperを追加し、Server Componentでユーザー情報を取得してpropsで渡す
- Suspense境界を追加してストリーミング対応

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `src/app/page.tsx` | HomeStartButtonWrapper追加、Suspense追加 |
| `src/features/home/components/home-start-button/HomeStartButton.tsx` | props受け取り型に変更、useZennConnectionStatus削除 |

## Test plan

- [ ] 未ログイン状態でホームページにアクセス → `/about`に遷移することを確認
- [ ] ログイン済み・Zenn未連携状態でホームページにアクセス → `/about`に遷移することを確認  
- [ ] ログイン済み・Zenn連携済み状態でホームページにアクセス → `/connection`に遷移することを確認
- [ ] 音声再生が正常に動作することを確認

Closes #134

---
*Note: PR #141 was accidentally merged and reverted. This is a re-creation.*