### PR TITLE
refactor: HeroContextのRSC初期化

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import { baseMetadata } from "@/config/metadata";
 import type { Metadata } from "next";
 import { Header } from "@/components/layout/header/Header";
 import { Footer } from "@/components/layout/footer/Footer";
-import { HeroProvider } from "@/contexts/HeroContext";
+import HeroProviderWrapper from "@/components/providers/HeroProviderWrapper";
 import CommonContainer from "@/components/common/container/CommonContainer";
 import "@/styles/globals.css";
 import { ControlViewport } from "@/components/layout/control-viewport/ControlViewport";
@@ -63,7 +63,7 @@ export default function RootLayout({
 				>
 					<SignOutHandler>
 						<AudioProvider>
-							<HeroProvider>
+							<HeroProviderWrapper>
 								<HomeAnimationProvider>
 									<CommonContainer>
 										<ControlViewport />
@@ -72,7 +72,7 @@ export default function RootLayout({
 										<Footer />
 									</CommonContainer>
 								</HomeAnimationProvider>
-							</HeroProvider>
+							</HeroProviderWrapper>
 						</AudioProvider>
 					</SignOutHandler>
 				</ClerkProviderWrapper>

--- a/src/components/providers/HeroProviderWrapper.tsx
+++ b/src/components/providers/HeroProviderWrapper.tsx
@@ -1,0 +1,36 @@
+import { Suspense } from "react";
+import { getHeroInitialData } from "@/features/user/_lib/fetcher";
+import { HeroProvider } from "@/contexts/HeroContext";
+
+interface HeroProviderWrapperProps {
+	children: React.ReactNode;
+}
+
+/**
+ * 非同期データ取得を行う内部コンポーネント
+ */
+async function HeroDataFetcher({
+	children,
+}: {
+	children: React.ReactNode;
+}): Promise<React.ReactElement> {
+	const initialData = await getHeroInitialData();
+
+	return <HeroProvider initialData={initialData}>{children}</HeroProvider>;
+}
+
+/**
+ * HeroProvider用のServer Componentラッパー
+ *
+ * サーバーサイドで初期Hero データを取得し、HeroProviderに渡す。
+ * Suspenseで囲むことで、プリレンダリング中のエラーを回避する。
+ */
+const HeroProviderWrapper = ({ children }: HeroProviderWrapperProps) => {
+	return (
+		<Suspense fallback={<HeroProvider>{children}</HeroProvider>}>
+			<HeroDataFetcher>{children}</HeroDataFetcher>
+		</Suspense>
+	);
+};
+
+export default HeroProviderWrapper;

--- a/src/contexts/HeroContext.tsx
+++ b/src/contexts/HeroContext.tsx
@@ -41,15 +41,44 @@ const CACHE_DURATION = 5 * 60 * 1000;
 // メモリキャッシュ
 const heroDataCache = new Map<string, CacheEntry>();
 
+// RSC初期データの型（fetcher.tsと同じ型）
+export type HeroInitialData = {
+	level: number;
+	isGuestUser: boolean;
+} | null;
+
 // Providerコンポーネント
-export const HeroProvider = ({ children }: { children: ReactNode }) => {
+interface HeroProviderProps {
+	children: ReactNode;
+	initialData?: HeroInitialData;
+}
+
+export const HeroProvider = ({ children, initialData }: HeroProviderProps) => {
 	const { user, isLoaded } = useUser();
-	const [heroData, setHeroData] = useState<HeroData>({
-		...strengthHeroData,
-		level: 1,
+
+	// 初期データがある場合はそれを使用、なければデフォルト値
+	const [heroData, setHeroData] = useState<HeroData>(() => {
+		if (initialData) {
+			return {
+				...strengthHeroData,
+				level: initialData.level,
+				currentExp: 40,
+				nextLevelExp: 100,
+				remainingArticles: 1,
+			};
+		}
+		return {
+			...strengthHeroData,
+			level: 1,
+		};
 	});
-	const [isLoading, setIsLoading] = useState(true);
+
+	// 初期データがある場合はローディング完了状態で開始
+	const [isLoading, setIsLoading] = useState(!initialData);
 	const [error, setError] = useState<string | null>(null);
+
+	// 初期データをキャッシュに保存（マウント時に1回のみ）
+	const initialDataCachedRef = useRef(false);
 
 	// AbortControllerのrefを管理
 	const abortControllerRef = useRef<AbortController | null>(null);
@@ -131,6 +160,24 @@ export const HeroProvider = ({ children }: { children: ReactNode }) => {
 			}
 
 			if (isLoaded && user) {
+				// RSC初期データがある場合は初回フェッチをスキップ
+				// （キャッシュ設定前でも初期データを信頼する）
+				if (initialData && retryCount === 0 && !initialDataCachedRef.current) {
+					// キャッシュに保存してフラグを立てる
+					const initialHeroData: HeroData = {
+						...strengthHeroData,
+						level: initialData.level,
+						currentExp: 40,
+						nextLevelExp: 100,
+						remainingArticles: 1,
+					};
+					setCachedHeroData(user.id, initialHeroData);
+					initialDataCachedRef.current = true;
+					setIsLoading(false);
+					setError(null);
+					return;
+				}
+
 				// キャッシュをチェック
 				const cachedData = getCachedHeroData(user.id);
 				if (cachedData && retryCount === 0) {
@@ -297,7 +344,7 @@ export const HeroProvider = ({ children }: { children: ReactNode }) => {
 				}
 			}
 		},
-		[isLoaded, user, getCachedHeroData, setCachedHeroData]
+		[isLoaded, user, getCachedHeroData, setCachedHeroData, initialData]
 	);
 
 	// 外部から呼び出し可能な再取得関数（キャッシュを無効化）

--- a/src/features/user/_lib/fetcher.ts
+++ b/src/features/user/_lib/fetcher.ts
@@ -16,6 +16,7 @@ export type User = {
 	clerkId: string;
 	email: string | null;
 	zennUsername: string | null;
+	zennArticleCount: number;
 	createdAt: Date;
 	updatedAt: Date;
 } | null;
@@ -43,6 +44,7 @@ async function getCachedUserData(clerkId: string): Promise<User> {
 				clerkId: true,
 				email: true,
 				zennUsername: true,
+				zennArticleCount: true,
 				createdAt: true,
 				updatedAt: true,
 			},
@@ -136,4 +138,55 @@ export const getUserWithArticles = cache(async (): Promise<UserWithArticles> => 
 		articles,
 		articleCount: articles.length,
 	};
+});
+
+/**
+ * HeroProvider用の初期データを取得する関数
+ *
+ * サーバーサイドでユーザーの記事数を取得し、HeroProviderの初期化に使用。
+ * - ログインユーザー: DBの zennArticleCount を使用
+ * - ゲストユーザー: null を返す（クライアントでaoyamadevのデータを取得）
+ *
+ * 注意: この関数はroot layoutで呼ばれるため、プリレンダリング時の
+ * connection()エラーを適切にハンドリングする必要がある。
+ *
+ * @returns 初期レベル（記事数）またはnull
+ */
+export type HeroInitialData = {
+	level: number;
+	isGuestUser: boolean;
+} | null;
+
+export const getHeroInitialData = cache(async (): Promise<HeroInitialData> => {
+	try {
+		// auth()を直接使用（connection()を使わない）
+		// プリレンダリング中は userId が null になるだけでエラーにはならない
+		const { userId } = await auth();
+
+		if (!userId) {
+			return null;
+		}
+
+		// キャッシュされたユーザーデータを取得
+		const user = await getCachedUserData(userId);
+
+		if (!user) {
+			return null;
+		}
+
+		// Zenn未連携の場合はnullを返す（クライアントでフォールバック処理）
+		if (!user.zennUsername) {
+			return null;
+		}
+
+		// ログイン済み＆Zenn連携済みの場合、DBの記事数をレベルとして返す
+		return {
+			level: Math.max(user.zennArticleCount, 1),
+			isGuestUser: false,
+		};
+	} catch {
+		// エラー時はnullを返す
+		// クライアント側のHeroProviderがフォールバック処理を行う
+		return null;
+	}
 });


### PR DESCRIPTION
## Summary

Issue #131 (useEffectパターンの最適化) の Sub-Issue #137 として、HeroContextの初期化をサーバーサイドで行うよう改善しました。

### 変更内容

- **getHeroInitialData関数を追加** (`src/features/user/_lib/fetcher.ts`)
  - サーバーサイドでユーザーの記事数を取得
  - ログインユーザー＆Zenn連携済みの場合のみデータを返す
  - プリレンダリング中は `null` を返してフォールバック

- **HeroProviderWrapperを新規作成** (`src/components/providers/HeroProviderWrapper.tsx`)
  - Server Componentラッパー
  - Suspenseで囲んでプリレンダリングエラーを回避
  - async `HeroDataFetcher` でデータ取得

- **HeroProviderにinitialData prop追加** (`src/contexts/HeroContext.tsx`)
  - 初期データがある場合はローディング完了状態で開始
  - クライアントサイドのフェッチをスキップ可能に

### 効果

- ログイン済み＆Zenn連携済みユーザーで、初期表示時のローディング状態を削減
- サーバーサイドでデータを取得するため、クライアント側のAPI呼び出しを削減

### 技術的なポイント

- `connection()` を使わず `auth()` を直接使用（プリレンダリング対策）
- Suspense境界でフォールバック（初期データなしのHeroProvider）を設定
- 既存のクライアントサイドロジックとの後方互換性を維持

Closes #137

## Test plan

- [x] ビルドが成功すること（`pnpm build`）
- [x] Lint/Type checkが通ること
- [x] ログイン状態でダッシュボードにアクセスし、レベル表示を確認
- [x] 未ログイン状態でダッシュボードにアクセスし、ゲストデータ表示を確認
- [x] ページ遷移後もHeroContextのデータが保持されること