### PR TITLE
fix: スケルトンUI用CSS変数名の修正

### DIFF
--- a/src/features/about/components/about-guide-icon-client/AboutGuideIconClient.module.css
+++ b/src/features/about/components/about-guide-icon-client/AboutGuideIconClient.module.css
@@ -20,9 +20,9 @@
 	inset: 0;
 	background: linear-gradient(
 		90deg,
-		var(--color-bg-skeleton) 25%,
-		var(--color-bg-skeleton-highlight) 50%,
-		var(--color-bg-skeleton) 75%
+		var(--color-skeleton-base) 25%,
+		var(--color-skeleton-highlight) 50%,
+		var(--color-skeleton-base) 75%
 	);
 	background-size: 200% 100%;
 	animation: skeleton-shimmer 1.5s ease-in-out infinite;

--- a/src/features/dashboard/components/dashboard-hero-icon-client/DashboardHeroIconClient.module.css
+++ b/src/features/dashboard/components/dashboard-hero-icon-client/DashboardHeroIconClient.module.css
@@ -9,9 +9,9 @@
 	inset: 0;
 	background: linear-gradient(
 		90deg,
-		var(--color-bg-skeleton) 25%,
-		var(--color-bg-skeleton-highlight) 50%,
-		var(--color-bg-skeleton) 75%
+		var(--color-skeleton-base) 25%,
+		var(--color-skeleton-highlight) 50%,
+		var(--color-skeleton-base) 75%
 	);
 	background-size: 200% 100%;
 	animation: skeleton-shimmer 1.5s ease-in-out infinite;

--- a/src/features/dashboard/components/dashboard-hero-section/DashboardHeroSection.module.css
+++ b/src/features/dashboard/components/dashboard-hero-section/DashboardHeroSection.module.css
@@ -69,9 +69,9 @@
 	inset: 0;
 	background: linear-gradient(
 		90deg,
-		var(--color-bg-skeleton) 25%,
-		var(--color-bg-skeleton-highlight) 50%,
-		var(--color-bg-skeleton) 75%
+		var(--color-skeleton-base) 25%,
+		var(--color-skeleton-highlight) 50%,
+		var(--color-skeleton-base) 75%
 	);
 	background-size: 200% 100%;
 	animation: skeleton-shimmer 1.5s ease-in-out infinite;


### PR DESCRIPTION
## Summary

スケルトンUIで使用しているCSS変数名が `globals.css` で定義されている名前と異なっていた問題を修正しました。

### 修正内容

| 誤った変数名 | 正しい変数名 |
|-------------|-------------|
| `--color-bg-skeleton` | `--color-skeleton-base` |
| `--color-bg-skeleton-highlight` | `--color-skeleton-highlight` |

### 修正ファイル

- `src/features/about/components/about-guide-icon-client/AboutGuideIconClient.module.css`
- `src/features/dashboard/components/dashboard-hero-icon-client/DashboardHeroIconClient.module.css`
- `src/features/dashboard/components/dashboard-hero-section/DashboardHeroSection.module.css`

### 効果

- スケルトンUIのグラデーションが正しく表示されるようになる

Closes #139

## Test plan

- [x] ビルドが成功すること
- [x] ダッシュボードページでスケルトンUIが正しく表示されること
- [x] Aboutページでガイドアイコンのスケルトンが正しく表示されること