### PR TITLE
refactor: AboutGuideIconClientのスケルトンUI削除

### DIFF
--- a/src/features/about/components/about-guide-icon-client/AboutGuideIconClient.module.css
+++ b/src/features/about/components/about-guide-icon-client/AboutGuideIconClient.module.css
@@ -14,26 +14,3 @@
 	width: 100%;
 	height: 100%;
 }
-
-.about-guide-icon-skeleton {
-	position: absolute;
-	inset: 0;
-	background: linear-gradient(
-		90deg,
-		var(--color-skeleton-base) 25%,
-		var(--color-skeleton-highlight) 50%,
-		var(--color-skeleton-base) 75%
-	);
-	background-size: 200% 100%;
-	animation: skeleton-shimmer 1.5s ease-in-out infinite;
-	border-radius: var(--border-radius-small);
-}
-
-@keyframes skeleton-shimmer {
-	0% {
-		background-position: 200% 0;
-	}
-	100% {
-		background-position: -200% 0;
-	}
-}

--- a/src/features/about/components/about-guide-icon-client/AboutGuideIconClient.tsx
+++ b/src/features/about/components/about-guide-icon-client/AboutGuideIconClient.tsx
@@ -2,7 +2,6 @@
 
 import Image from "next/image";
 import styles from "./AboutGuideIconClient.module.css";
-import { useSkeletonWithTimeout } from "@/hooks/useSkeletonWithTimeout";
 
 interface AboutGuideIconClientProps {
 	iconSrc: string;
@@ -10,8 +9,6 @@ interface AboutGuideIconClientProps {
 }
 
 const AboutGuideIconClient: React.FC<AboutGuideIconClientProps> = ({ iconSrc, alt }) => {
-	const { showSkeleton, onImageLoad } = useSkeletonWithTimeout([iconSrc]);
-
 	return (
 		<div className={styles["about-guide-icon-wrapper"]}>
 			<Image
@@ -20,10 +17,10 @@ const AboutGuideIconClient: React.FC<AboutGuideIconClientProps> = ({ iconSrc, al
 				width={100}
 				height={100}
 				preload={true}
-				onLoad={onImageLoad}
+				placeholder="blur"
+				blurDataURL={iconSrc}
 				className={styles["about-guide-icon-image"]}
 			/>
-			{showSkeleton && <div className={styles["about-guide-icon-skeleton"]} />}
 		</div>
 	);
 };


### PR DESCRIPTION
## Summary

`AboutGuideIconClient` コンポーネントから不要なスケルトンUIを削除しました。

### 削除内容

- `useSkeletonWithTimeout` フックの使用
- スケルトン表示の JSX (`{showSkeleton && ...}`)
- CSS Module のスケルトン関連スタイル (`.about-guide-icon-skeleton`, `@keyframes skeleton-shimmer`)

### 理由

`placeholder="blur"` が設定されているため、Next.js の Image コンポーネントが自動的にプレースホルダーを表示する。
そのため、追加のスケルトンUIは不要。

## Test plan

- [x] ビルドが成功すること
- [x] About ページでガイドアイコンが正しく表示されること