### PR TITLE
fix: ExploreArticleAnalysisの連携ページへボタンにクリックサウンド遅延を追加

### DIFF
--- a/src/features/explore/components/explore-article-analysis/ExploreArticleAnalysis.tsx
+++ b/src/features/explore/components/explore-article-analysis/ExploreArticleAnalysis.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment } from "react";
 import { useUser } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import type { UIMessage, TextUIPart } from "ai";
 import styles from "./ExploreArticleAnalysis.module.css";
@@ -31,12 +32,18 @@ const ExploreArticleAnalysis: React.FC<ExploreArticleAnalysisProps> = ({
 	error,
 }) => {
 	const { user } = useUser();
+	const router = useRouter();
 
 	const { playClickSound } = useClickSound({
 		soundPath: "/audio/click-sound_decision.mp3",
 		volume: 0.5,
 		delay: 190, // 190ミリ秒 = 0.19秒の遅延
 	});
+
+	const handleConnectionLinkClick = (e: React.MouseEvent) => {
+		e.preventDefault();
+		playClickSound(() => router.push("/connection"));
+	};
 
 	// 読み込み中はローディングを表示する（遷移時などDynamic Importのloadingが出ない場合への対応）
 	if (!isLoaded || !isZennInfoLoaded) {
@@ -68,7 +75,7 @@ const ExploreArticleAnalysis: React.FC<ExploreArticleAnalysisProps> = ({
 						<Link
 							href="/connection"
 							className={styles["to-the-link-page-button"]}
-							onClick={() => playClickSound()}
+							onClick={handleConnectionLinkClick}
 						>
 							<span className={styles["to-the-link-page-button-text"]}>連携ページへ</span>
 						</Link>


### PR DESCRIPTION
## Summary

`ExploreArticleAnalysis` コンポーネントの「連携ページへ」ボタンで、クリックサウンドが正しく再生される前にページ遷移が始まってしまう問題を修正しました。

### 問題の原因

修正前は `playClickSound()` をコールバックなしで呼んでいたため、`useClickSound` の `delay: 190` が効いていなかった。

```tsx
// Before: delay が効かない
<Link href="/connection" onClick={() => playClickSound()}>
```

### 修正内容

- `e.preventDefault()` で Link のデフォルト動作を止める
- `playClickSound()` にコールバックを渡して、190ms 後にページ遷移

```tsx
// After: delay: 190 が効く
const handleConnectionLinkClick = (e: React.MouseEvent) => {
    e.preventDefault();
    playClickSound(() => router.push("/connection"));
};
```

Closes #142

## Test plan

- [x] ビルドが成功すること
- [x] Exploreページでゲストユーザー時に「連携ページへ」ボタンをクリック
- [x] クリックサウンドが再生されてからページ遷移すること（190ms遅延）