### PR TITLE
refactor: Storage ユーティリティの統一

### DIFF
--- a/src/features/connection/hooks/useMessageStorage.ts
+++ b/src/features/connection/hooks/useMessageStorage.ts
@@ -4,6 +4,7 @@ import "client-only";
 
 import { useEffect, Dispatch, SetStateAction } from "react";
 import { LOGOUT_FLAG_KEY } from "@/features/connection/constants";
+import { storage } from "@/utils/storage";
 
 // ローカルストレージのキー
 const SUCCESS_MESSAGE_KEY = "zenn_success_message";
@@ -22,29 +23,25 @@ export const useMessageStorage = ({
 }: UseMessageStorageProps) => {
 	useEffect(() => {
 		if (typeof window !== "undefined") {
-			try {
-				// 成功メッセージを取得
-				const savedSuccessMessage = localStorage.getItem(SUCCESS_MESSAGE_KEY);
-				if (savedSuccessMessage) {
-					setSuccess(savedSuccessMessage);
-					localStorage.removeItem(SUCCESS_MESSAGE_KEY);
-				}
+			// 成功メッセージを取得
+			const savedSuccessMessage = storage.get(SUCCESS_MESSAGE_KEY);
+			if (savedSuccessMessage) {
+				setSuccess(savedSuccessMessage);
+				storage.remove(SUCCESS_MESSAGE_KEY);
+			}
 
-				// 連携解除メッセージを取得
-				const savedReleaseMessage = localStorage.getItem(RELEASE_MESSAGE_KEY);
-				if (savedReleaseMessage) {
-					setReleaseMessage(savedReleaseMessage);
-					localStorage.removeItem(RELEASE_MESSAGE_KEY);
-				}
+			// 連携解除メッセージを取得
+			const savedReleaseMessage = storage.get(RELEASE_MESSAGE_KEY);
+			if (savedReleaseMessage) {
+				setReleaseMessage(savedReleaseMessage);
+				storage.remove(RELEASE_MESSAGE_KEY);
+			}
 
-				// ログアウトフラグを確認
-				const logoutFlag = localStorage.getItem(LOGOUT_FLAG_KEY);
-				if (logoutFlag === "true") {
-					setWasLoggedOut(true);
-					localStorage.removeItem(LOGOUT_FLAG_KEY);
-				}
-			} catch (_error) {
-				// Cache Componentsモードでstorageアクセスが制限される場合は無視
+			// ログアウトフラグを確認
+			const logoutFlag = storage.get(LOGOUT_FLAG_KEY);
+			if (logoutFlag === "true") {
+				setWasLoggedOut(true);
+				storage.remove(LOGOUT_FLAG_KEY);
 			}
 		}
 	}, [setSuccess, setReleaseMessage, setWasLoggedOut]);

--- a/src/features/connection/hooks/useSessionManagement.ts
+++ b/src/features/connection/hooks/useSessionManagement.ts
@@ -5,6 +5,7 @@ import "client-only";
 import { useEffect, Dispatch, SetStateAction } from "react";
 import { UserResource } from "@clerk/types";
 import { SESSION_ID_KEY, LOGOUT_FLAG_KEY } from "@/features/connection/constants";
+import { storage } from "@/utils/storage";
 
 interface UseSessionManagementProps {
 	user: UserResource | null | undefined;
@@ -23,34 +24,30 @@ export const useSessionManagement = ({
 }: UseSessionManagementProps) => {
 	useEffect(() => {
 		if (typeof window !== "undefined") {
-			try {
-				if (user) {
-					// ユーザーがログインしている場合
-					const currentSessionId = localStorage.getItem(SESSION_ID_KEY);
-					const logoutFlag = localStorage.getItem(LOGOUT_FLAG_KEY);
+			if (user) {
+				// ユーザーがログインしている場合
+				const currentSessionId = storage.get(SESSION_ID_KEY);
+				const logoutFlag = storage.get(LOGOUT_FLAG_KEY);
 
-					// ログアウトフラグがある場合またはセッションIDが変更された場合
-					if (logoutFlag === "true" || !currentSessionId || currentSessionId !== user.id) {
-						// フラグをクリア
-						localStorage.removeItem(LOGOUT_FLAG_KEY);
-						localStorage.removeItem("zenn_previous_user");
-						localStorage.setItem(SESSION_ID_KEY, user.id);
+				// ログアウトフラグがある場合またはセッションIDが変更された場合
+				if (logoutFlag === "true" || !currentSessionId || currentSessionId !== user.id) {
+					// フラグをクリア
+					storage.remove(LOGOUT_FLAG_KEY);
+					storage.remove("zenn_previous_user");
+					storage.set(SESSION_ID_KEY, user.id);
 
-						// DBのデータは保持するため、リセット処理は行わない
-						// フラグのみ設定してuseUserInfoでDBから既存のデータを取得させる
-						setWasLoggedOut(true);
-						setIsNewSession(true);
-					}
-				} else if (isLoaded && !user) {
-					// ユーザーがログアウトしている場合はセッションIDを削除
-					localStorage.removeItem(SESSION_ID_KEY);
-					// ログアウト時にZennユーザー名をクリア（UIのみ）
-					setZennUsername("");
-					// ログアウト時に必ずフラグを設定
-					localStorage.setItem(LOGOUT_FLAG_KEY, "true");
+					// DBのデータは保持するため、リセット処理は行わない
+					// フラグのみ設定してuseUserInfoでDBから既存のデータを取得させる
+					setWasLoggedOut(true);
+					setIsNewSession(true);
 				}
-			} catch (_error) {
-				// Cache Componentsモードでstorageアクセスが制限される場合は無視
+			} else if (isLoaded && !user) {
+				// ユーザーがログアウトしている場合はセッションIDを削除
+				storage.remove(SESSION_ID_KEY);
+				// ログアウト時にZennユーザー名をクリア（UIのみ）
+				setZennUsername("");
+				// ログアウト時に必ずフラグを設定
+				storage.set(LOGOUT_FLAG_KEY, "true");
 			}
 		}
 	}, [user, isLoaded, setWasLoggedOut, setIsNewSession, setZennUsername]);

--- a/src/features/connection/hooks/useSignOutHandler.ts
+++ b/src/features/connection/hooks/useSignOutHandler.ts
@@ -6,6 +6,7 @@ import { useEffect } from "react";
 import { useUser } from "@clerk/nextjs";
 import { UserInfo } from "@/features/connection/types";
 import { SESSION_ID_KEY, LOGOUT_FLAG_KEY } from "@/features/connection/constants";
+import { storage } from "@/utils/storage";
 
 interface UseSignOutHandlerProps {
 	userInfo: UserInfo | null;
@@ -28,11 +29,7 @@ export const useSignOutHandler = ({
 		const handleBeforeUnload = () => {
 			// ユーザーがブラウザを閉じたり更新したりする際に、セッション情報を保持
 			if (user) {
-				try {
-					localStorage.setItem(SESSION_ID_KEY, user.id);
-				} catch (_error) {
-					// Cache Componentsモードでstorageアクセスが制限される場合は無視
-				}
+				storage.set(SESSION_ID_KEY, user.id);
 			}
 		};
 
@@ -48,16 +45,12 @@ export const useSignOutHandler = ({
 		if (typeof window !== "undefined") {
 			// 同期的な連携解除実行関数
 			const syncResetZennConnection = () => {
-				try {
-					// 確実にフラグを設定
-					localStorage.setItem(LOGOUT_FLAG_KEY, "true");
+				// 確実にフラグを設定
+				storage.set(LOGOUT_FLAG_KEY, "true");
 
-					// 現在のユーザーIDを保存（ログ用）
-					if (user?.id) {
-						localStorage.setItem("zenn_previous_user", user.id);
-					}
-				} catch (_error) {
-					// Cache Componentsモードでstorageアクセスが制限される場合は無視
+				// 現在のユーザーIDを保存（ログ用）
+				if (user?.id) {
+					storage.set("zenn_previous_user", user.id);
 				}
 
 				// 画面上の状態をクリア
@@ -74,33 +67,21 @@ export const useSignOutHandler = ({
 					syncResetZennConnection();
 
 					// 次にセッション関連の状態をクリア
-					try {
-						localStorage.setItem(LOGOUT_FLAG_KEY, "true");
-						localStorage.removeItem(SESSION_ID_KEY);
-					} catch (_error) {
-						// Cache Componentsモードでstorageアクセスが制限される場合は無視
-					}
+					storage.set(LOGOUT_FLAG_KEY, "true");
+					storage.remove(SESSION_ID_KEY);
 
 					// DBのデータ（zennUsername、zennArticleCount、level）は一切変更しない
 					// 画面上の表示のみクリアする
 					// サインアウト後も次回ログイン時にZenn連携が維持されるようにする
 
 					// 最後の保険として、再度ログアウトフラグを設定
-					try {
-						localStorage.setItem(LOGOUT_FLAG_KEY, "true");
-						localStorage.removeItem(SESSION_ID_KEY);
-					} catch (_error) {
-						// Cache Componentsモードでstorageアクセスが制限される場合は無視
-					}
+					storage.set(LOGOUT_FLAG_KEY, "true");
+					storage.remove(SESSION_ID_KEY);
 				} catch (err) {
 					console.error("サインアウトハンドラーエラー:", err);
 					// エラーが発生しても必ずログアウトフラグは維持する
-					try {
-						localStorage.setItem(LOGOUT_FLAG_KEY, "true");
-						localStorage.removeItem(SESSION_ID_KEY);
-					} catch (_error) {
-						// Cache Componentsモードでstorageアクセスが制限される場合は無視
-					}
+					storage.set(LOGOUT_FLAG_KEY, "true");
+					storage.remove(SESSION_ID_KEY);
 				}
 			};
 

--- a/src/features/home/contexts/HomeAnimationContext.tsx
+++ b/src/features/home/contexts/HomeAnimationContext.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { createContext, use, useState, useEffect, ReactNode } from "react";
+import { storage } from "@/utils/storage";
 
 interface HomeAnimationContextType {
 	isAnimationStarted: boolean;
@@ -21,21 +22,15 @@ export const HomeAnimationProvider = ({ children }: { children: ReactNode }) => 
 		// SSR中はsessionStorageにアクセスしない
 		if (typeof window === "undefined") return;
 
-		try {
-			const hasVisited = sessionStorage.getItem("hero-visited");
+		const hasVisited = storage.get("hero-visited", "session");
 
-			if (hasVisited) {
-				setIsFirstVisit(false);
-				setIsAnimationStarted(true);
-				setIsImageVisible(true);
-			} else {
-				setIsFirstVisit(true);
-				sessionStorage.setItem("hero-visited", "true");
-			}
-		} catch (_error) {
-			// Cache Componentsモードでstorageアクセスが制限される場合は
-			// 初回訪問として扱う
+		if (hasVisited) {
+			setIsFirstVisit(false);
+			setIsAnimationStarted(true);
+			setIsImageVisible(true);
+		} else {
 			setIsFirstVisit(true);
+			storage.set("hero-visited", "true", "session");
 		}
 	}, []);
 

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -3,6 +3,7 @@
 import "client-only";
 
 import { useState, useEffect, Dispatch, SetStateAction } from "react";
+import { storage } from "@/utils/storage";
 
 export function useLocalStorage<T>(key: string, initialValue: T): [T, Dispatch<SetStateAction<T>>] {
 	// サーバーサイドレンダリング時は初期値のみを使用
@@ -14,34 +15,29 @@ export function useLocalStorage<T>(key: string, initialValue: T): [T, Dispatch<S
 		// サーバーサイドレンダリング時は実行しない
 		if (typeof window === "undefined") return;
 
-		try {
-			const item = localStorage.getItem(key);
-			if (item) {
+		const item = storage.get(key);
+		if (item) {
+			try {
 				setStoredValue(JSON.parse(item));
-			} else {
-				// アイテムがない場合は初期値を設定
-				localStorage.setItem(key, JSON.stringify(initialValue));
+			} catch {
+				// JSON パースに失敗した場合は初期値を使用
 			}
-		} catch (_error) {
-			// Cache Componentsモードでstorageアクセスが制限される場合は
-			// 初期値をそのまま使用
+		} else {
+			// アイテムがない場合は初期値を設定
+			storage.set(key, JSON.stringify(initialValue));
 		}
 	}, [key, initialValue]);
 
 	// 値を設定する関数
 	const setValue: Dispatch<SetStateAction<T>> = (value) => {
-		try {
-			// 新しい値を状態に設定
-			const valueToStore = value instanceof Function ? value(storedValue) : value;
-			setStoredValue(valueToStore);
+		// 新しい値を状態に設定
+		const valueToStore = value instanceof Function ? value(storedValue) : value;
+		setStoredValue(valueToStore);
 
-			// サーバーサイドレンダリング時は実行しない
-			if (typeof window !== "undefined") {
-				// ローカルストレージに保存
-				localStorage.setItem(key, JSON.stringify(valueToStore));
-			}
-		} catch (_error) {
-			// Cache Componentsモードでstorageアクセスが制限される場合は無視
+		// サーバーサイドレンダリング時は実行しない
+		if (typeof window !== "undefined") {
+			// ローカルストレージに保存
+			storage.set(key, JSON.stringify(valueToStore));
 		}
 	};
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,94 @@
+/**
+ * Storage ユーティリティ
+ * localStorage / sessionStorage への安全なアクセスを提供
+ * - SSR 時の window チェック
+ * - Cache Components モードでのエラーハンドリング
+ */
+
+type StorageType = "local" | "session";
+
+const getStorage = (type: StorageType): Storage | null => {
+	if (typeof window === "undefined") return null;
+	return type === "local" ? localStorage : sessionStorage;
+};
+
+/**
+ * Storage から値を取得
+ */
+export const getItem = (key: string, type: StorageType = "local"): string | null => {
+	const storage = getStorage(type);
+	if (!storage) return null;
+
+	try {
+		return storage.getItem(key);
+	} catch {
+		// Cache Components モードで storage アクセスが制限される場合
+		return null;
+	}
+};
+
+/**
+ * Storage に値を設定
+ */
+export const setItem = (key: string, value: string, type: StorageType = "local"): boolean => {
+	const storage = getStorage(type);
+	if (!storage) return false;
+
+	try {
+		storage.setItem(key, value);
+		return true;
+	} catch {
+		// Cache Components モードで storage アクセスが制限される場合
+		return false;
+	}
+};
+
+/**
+ * Storage から値を削除
+ */
+export const removeItem = (key: string, type: StorageType = "local"): boolean => {
+	const storage = getStorage(type);
+	if (!storage) return false;
+
+	try {
+		storage.removeItem(key);
+		return true;
+	} catch {
+		// Cache Components モードで storage アクセスが制限される場合
+		return false;
+	}
+};
+
+/**
+ * JSON として値を取得
+ */
+export const getJSON = <T>(key: string, type: StorageType = "local"): T | null => {
+	const value = getItem(key, type);
+	if (!value) return null;
+
+	try {
+		return JSON.parse(value) as T;
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * JSON として値を設定
+ */
+export const setJSON = <T>(key: string, value: T, type: StorageType = "local"): boolean => {
+	try {
+		return setItem(key, JSON.stringify(value), type);
+	} catch {
+		return false;
+	}
+};
+
+// 名前付きエクスポートをまとめたオブジェクト
+export const storage = {
+	get: getItem,
+	set: setItem,
+	remove: removeItem,
+	getJSON,
+	setJSON,
+};


### PR DESCRIPTION
## Summary

`localStorage` / `sessionStorage` へのアクセスを統一されたユーティリティに移行しました。

## 変更内容

### 新規作成

`src/utils/storage.ts`:
- `storage.get(key, type?)` - 値を取得
- `storage.set(key, value, type?)` - 値を設定
- `storage.remove(key, type?)` - 値を削除
- `storage.getJSON<T>(key, type?)` - JSONとして取得
- `storage.setJSON<T>(key, value, type?)` - JSONとして設定

### 移行したファイル

| ファイル | 変更内容 |
|----------|----------|
| `useSignOutHandler.ts` | `localStorage.*` → `storage.*` |
| `useSessionManagement.ts` | 同上 |
| `useMessageStorage.ts` | 同上 |
| `useLocalStorage.ts` | 同上 |
| `HomeAnimationContext.tsx` | `sessionStorage.*` → `storage.*(key, "session")` |

## メリット

- SSR 時の `typeof window` チェックが一元化
- Cache Components モードでのエラーハンドリングが統一
- try-catch の重複削除
- コードの見通しが改善

## Test plan

- [x] `pnpm build` が成功することを確認
- [x] ログイン/ログアウトが正常に動作することを確認
- [x] ホームページのアニメーションが正常に動作することを確認

Closes #151