### PR TITLE
refactor: Howl オーディオ管理を useRef ベースに最適化

### DIFF
--- a/src/components/common/audio/audio-player/AudioPlayer.tsx
+++ b/src/components/common/audio/audio-player/AudioPlayer.tsx
@@ -2,7 +2,7 @@
 
 import "client-only";
 
-import { useEffect, useState, useCallback, memo } from "react";
+import { useEffect, useState, useCallback, useRef, memo } from "react";
 import { Howl } from "howler";
 import Image from "next/image";
 import styles from "./AudioPlayer.module.css";
@@ -18,7 +18,7 @@ interface AudioPlayerProps {
 const AudioPlayer = memo(({ src, className = "audio-button", volume = 1 }: AudioPlayerProps) => {
 	const [isPlaying, setIsPlaying] = useState(false);
 	const { isMuted, toggleMute } = useAudio();
-	const [sound, setSound] = useState<Howl | null>(null);
+	const soundRef = useRef<Howl | null>(null);
 
 	const handleClick = useCallback(() => {
 		toggleMute();
@@ -44,20 +44,25 @@ const AudioPlayer = memo(({ src, className = "audio-button", volume = 1 }: Audio
 			},
 		});
 
-		setSound(newSound);
+		soundRef.current = newSound;
+
 		return () => {
 			newSound.unload();
+			soundRef.current = null;
 		};
 	}, [src, volume]);
 
 	useEffect(() => {
+		const sound = soundRef.current;
 		if (!sound) return;
+
 		sound.mute(isMuted);
 
-		if (!isMuted && !isPlaying) {
+		// ミュート解除時に再生開始
+		if (!isMuted && !sound.playing()) {
 			sound.play();
 		}
-	}, [sound, isMuted, isPlaying]);
+	}, [isMuted]);
 
 	return (
 		<div className={styles["audio-button-container"]}>

--- a/src/hooks/useClickSound.ts
+++ b/src/hooks/useClickSound.ts
@@ -2,7 +2,7 @@
 
 import "client-only";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { Howl } from "howler";
 import { useAudio } from "@/contexts/AudioContext";
 
@@ -15,7 +15,7 @@ interface ClickSoundOptions {
 
 // クリックサウンドを再生するカスタムフック (Howler.js使用)
 export const useClickSound = (options: ClickSoundOptions = {}) => {
-	const [sound, setSound] = useState<Howl | null>(null);
+	const soundRef = useRef<Howl | null>(null);
 	const { isMuted } = useAudio();
 
 	// デフォルト値の設定
@@ -34,24 +34,26 @@ export const useClickSound = (options: ClickSoundOptions = {}) => {
 			html5: true,
 		});
 
-		setSound(howlSound);
+		soundRef.current = howlSound;
 
 		return () => {
 			howlSound.stop();
 			howlSound.unload();
+			soundRef.current = null;
 		};
 	}, [soundPath, volume]);
 
 	// グローバルなミュート状態をHowlインスタンスに同期する
 	useEffect(() => {
-		if (sound) {
-			sound.mute(isMuted);
+		if (soundRef.current) {
+			soundRef.current.mute(isMuted);
 		}
-	}, [sound, isMuted]);
+	}, [isMuted]);
 
 	// クリックサウンドを再生する関数
 	const playClickSound = useCallback(
 		(callback?: () => void) => {
+			const sound = soundRef.current;
 			if (sound) {
 				// 既に再生中の場合は停止してから再生
 				if (sound.playing()) {
@@ -68,7 +70,7 @@ export const useClickSound = (options: ClickSoundOptions = {}) => {
 				callback();
 			}
 		},
-		[sound, delay]
+		[delay]
 	);
 
 	return { playClickSound };


### PR DESCRIPTION
## Summary

Howler.js のオーディオインスタンス管理を `useState` から `useRef` に変更し、不要な再レンダーを防止しました。

## 変更内容

### useClickSound.ts

| Before | After |
|--------|-------|
| `useState<Howl \| null>(null)` | `useRef<Howl \| null>(null)` |
| `setSound(howlSound)` | `soundRef.current = howlSound` |
| 依存配列に `sound` | 依存配列から `sound` 削除 |

### AudioPlayer.tsx

| Before | After |
|--------|-------|
| `useState<Howl \| null>(null)` | `useRef<Howl \| null>(null)` |
| 依存配列に `isPlaying` | `sound.playing()` で直接確認 |

## メリット

- **再レンダー削減**: `setSound` による状態更新がなくなり、不要な再レンダーが発生しない
- **パフォーマンス向上**: 特にクリックサウンドが多用されるページで効果的
- **依存配列の簡素化**: `sound` を依存配列から削除できる

## Test plan

- [x] `pnpm build` が成功することを確認
- [x] クリックサウンドが正常に再生されることを確認
- [x] BGMのミュート/アンミュートが正常に動作することを確認

Closes #152