### PR TITLE
refactor: useMounted フックを作成

### DIFF
--- a/src/components/auth/auth-button/AuthButton.tsx
+++ b/src/components/auth/auth-button/AuthButton.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { SignInButton, useAuth } from "@clerk/nextjs";
-import { useState, useEffect } from "react";
 import { useClickSound } from "@/hooks/useClickSound";
+import { useMounted } from "@/hooks/useMounted";
 import styles from "./AuthButton.module.css";
 
 const AuthButton = () => {
@@ -14,12 +14,7 @@ const AuthButton = () => {
 		delay: 190, // 190ミリ秒 = 0.19秒の遅延
 	});
 	// クライアントサイドでのみレンダリングするための状態
-	const [mounted, setMounted] = useState(false);
-
-	// クライアントサイドでのみ実行される
-	useEffect(() => {
-		setMounted(true);
-	}, []);
+	const mounted = useMounted();
 
 	// サーバーサイドレンダリング時は何も表示しない
 	if (!mounted) {

--- a/src/hooks/useMounted.ts
+++ b/src/hooks/useMounted.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import "client-only";
+
+import { useState, useEffect } from "react";
+
+/**
+ * マウント状態を追跡するカスタムフック
+ *
+ * SSR/CSR の境界で、クライアントサイドでのみ表示したいコンテンツに使用する。
+ * ハイドレーションミスマッチを防ぐために、マウント後にのみ true を返す。
+ *
+ * @example
+ * ```tsx
+ * const mounted = useMounted();
+ *
+ * if (!mounted) {
+ *   return <Skeleton />;
+ * }
+ *
+ * return <ClientOnlyContent />;
+ * ```
+ */
+export function useMounted(): boolean {
+	const [mounted, setMounted] = useState(false);
+
+	useEffect(() => {
+		setMounted(true);
+	}, []);
+
+	return mounted;
+}


### PR DESCRIPTION
## Summary

マウント状態を追跡する汎用フック `useMounted` を作成しました。

## 変更内容

### 新規作成

`src/hooks/useMounted.ts`:
```typescript
export function useMounted(): boolean {
  const [mounted, setMounted] = useState(false);
  useEffect(() => {
    setMounted(true);
  }, []);
  return mounted;
}
```

### 適用

`AuthButton.tsx`:
```tsx
// Before
const [mounted, setMounted] = useState(false);
useEffect(() => {
  setMounted(true);
}, []);

// After
const mounted = useMounted();
```

## 用途

- SSR/CSR の境界でハイドレーションミスマッチを防止
- クライアントサイドでのみレンダリングしたいコンテンツに使用

## Test plan

- [x] `pnpm build` が成功することを確認
- [x] ブラウザコンソールにハイドレーションエラーが出ないことを確認
- [x] `/connection` ページでログインボタンが正常に表示されることを確認
- [x] ログインボタンをクリックしてサインインモーダルが開くことを確認
- [x] クリック時にサウンドが再生されることを確認
- [x] 初期ロード時にレイアウトシフトやチラつきがないことを確認

Closes #153