### PR TITLE
refactor: word-break: auto-phrase; を削除

### DIFF
--- a/src/features/dashboard/components/dashboard-activity-content/DashboardActivityContent.module.css
+++ b/src/features/dashboard/components/dashboard-activity-content/DashboardActivityContent.module.css
@@ -77,7 +77,6 @@
 .recent-activity-item-title {
 	width: fit-content;
 	text-wrap: pretty;
-	word-break: auto-phrase;
 	font-size: 1.125rem;
 	font-weight: var(--font-weight-normal);
 	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);

--- a/src/features/posts/components/post-card/PostCard.module.css
+++ b/src/features/posts/components/post-card/PostCard.module.css
@@ -26,7 +26,6 @@
 .post-card__title {
 	width: fit-content;
 	text-wrap: pretty;
-	word-break: auto-phrase;
 	font-size: 1.125rem;
 	font-weight: var(--font-weight-normal);
 	text-shadow: 1.5px 1.5px 0px var(--color-primary-black);


### PR DESCRIPTION
## Summary

`word-break: auto-phrase;` を削除しました。

## 変更内容

| ファイル | 削除したプロパティ |
|----------|-------------------|
| `PostCard.module.css` | `word-break: auto-phrase;` |
| `DashboardActivityContent.module.css` | `word-break: auto-phrase;` |

## 理由

- ブラウザサポートが限定的（Chrome 119+のみ）
- `text-wrap: pretty;` は残しており、テキスト折り返しは引き続き適用される

## Test plan

- [x] `pnpm build` が成功することを確認
- [x] `/posts` ページで記事カードのタイトルが正常に表示されることを確認
- [x] `/dashboard` ページでアクティビティのタイトルが正常に表示されることを確認

Closes #160