### PR TITLE
refactor: ConnectionZennForm のボタンテキストを「連携」に固定

### DIFF
--- a/src/features/connection/components/connection-zenn-form/ConnectionZennForm.tsx
+++ b/src/features/connection/components/connection-zenn-form/ConnectionZennForm.tsx
@@ -29,7 +29,7 @@ function SubmitButton({ disabled, hasUsername }: { disabled: boolean; hasUsernam
 			} ${isDisabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
 			disabled={isDisabled}
 		>
-			<div className={`${styles["connect-button-content"]}`}>{pending ? "連携中..." : "連携"}</div>
+			<div className={`${styles["connect-button-content"]}`}>連携</div>
 		</button>
 	);
 }


### PR DESCRIPTION
## Summary

- ボタンテキストを `{pending ? "連携中..." : "連携"}` から `連携` に固定

## 理由

- `LoadingIndicator` コンポーネントで「連携中」が表示されるため、ボタンテキストを変更する必要がない
- `opacity-50 cursor-not-allowed` スタイルで視覚的に押せないことがわかる

## Test plan

- [x] `/connection` ページで Zenn ユーザー名を入力して「連携」ボタンをクリック
- [x] ボタンテキストが「連携」のまま、LoadingIndicator が表示されることを確認

Closes #164