### PR TITLE
fix: HomeStartButton の初回ホバー時チラつきを修正

### DIFF
--- a/src/features/home/components/home-start-button/HomeStartButton.module.css
+++ b/src/features/home/components/home-start-button/HomeStartButton.module.css
@@ -38,7 +38,7 @@
 	top: 1px;
 	left: 0px;
 	height: 62px;
-	opacity: 0;
+	opacity: 0.001;
 
 	@media (width < 1280px) {
 		height: 56px;


### PR DESCRIPTION
## Summary

- `opacity: 0` を `opacity: 0.001` に変更
- ブラウザに事前レンダリングさせることで初回ホバー時のデコード遅延を解消

## 原因

ホバー画像が `opacity: 0` のため、ブラウザが画像の読み込み・デコードを遅延させていた。初回ホバー時に画像デコードが走ることでチラつきが発生。

## 解決策

`opacity: 0.001` にすることで、視覚的には完全に透明に見えるが、ブラウザには「表示される要素」として認識させ、事前にレンダリングさせる。

## Test plan

- [x] トップページを開く
- [x] 「はじめる」ボタンに初回ホバー
- [x] チラつきなく画像が切り替わることを確認

Closes #166