### PR TITLE
fix: トップページのアニメーション中に AudioPlayer がクリックできる問題を修正

### DIFF
--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -28,6 +28,7 @@ export const Header = () => {
 	// audioPlayer の定義をここに移動
 	const audioPlayer = (
 		<motion.div
+			className={shouldAnimateAudio && !isImageVisible ? "pointer-events-none" : "pointer-events-auto"}
 			initial={shouldAnimateAudio ? { opacity: 0 } : { opacity: 1 }}
 			animate={shouldAnimateAudio ? { opacity: isImageVisible ? 1 : 0 } : { opacity: 1 }}
 			transition={


### PR DESCRIPTION
## Summary

- アニメーション中（opacity: 0）の状態で AudioPlayer がクリックできてしまう問題を修正
- `pointer-events-none` / `pointer-events-auto` を追加

## 原因

Header.tsx で AudioPlayer をラップしている motion.div に `pointer-events` の制御がなかった。

## Test plan

- [ ] トップページを開く
- [ ] アニメーション中に AudioPlayer をクリックしても反応しないことを確認
- [ ] アニメーション完了後は正常にクリックできることを確認

Closes #168