### PR TITLE
refactor: ExplorePageClient のボタンテキストを「探索する」に固定

### DIFF
--- a/src/features/explore/components/explore-page-client/ExplorePageClient.tsx
+++ b/src/features/explore/components/explore-page-client/ExplorePageClient.tsx
@@ -148,18 +148,7 @@ const ExplorePageClient = ({ initialZennUsername }: Props) => {
 										height={18}
 										className={styles["explore-analyze-button-icon"]}
 									/>
-									{isAnalyzing || status === "streaming" ? (
-										<div className={styles["explore-analyze-button-loading-indicator"]}>
-											<span>探索中</span>
-											<span className={styles["loading-dots"]}>
-												<span className={styles["loading-dot"]}>.</span>
-												<span className={styles["loading-dot"]}>.</span>
-												<span className={styles["loading-dot"]}>.</span>
-											</span>
-										</div>
-									) : (
-										<span>探索する</span>
-									)}
+									<span>探索する</span>
 								</span>
 							</button>
 						</div>


### PR DESCRIPTION
## Summary

- ボタンテキストの条件分岐を削除し、「探索する」に固定
- 12行削減

## 理由

- `ExploreArticleAnalysis` の h2 タイトルが「探索中...」になるため、ボタンテキストを変更する必要がない
- ボタンは `disabled` + `explore-analyzing` スタイルで視覚的に押せないことがわかる

## Test plan

- [x] `/explore` ページを開く
- [x] 「探索する」ボタンをクリック
- [x] ボタンテキストが「探索する」のまま、h2 タイトルが「探索中...」になることを確認

Closes #170