### PR TITLE
refactor: LoadingIndicator のフォントサイズとメディアクエリを整理

### DIFF
--- a/src/features/connection/components/connection-auth-section/ConnectionAuthSection.module.css
+++ b/src/features/connection/components/connection-auth-section/ConnectionAuthSection.module.css
@@ -126,13 +126,9 @@
 }
 
 .loading-indicator {
-	font-size: 1.125rem;
+	font-size: 1rem;
 
 	@media (width < 768px) {
-		font-size: 1rem;
-	}
-
-	@media (width < 640px) {
 		font-size: 0.875rem;
 	}
 }

--- a/src/features/connection/components/connection-message-display/ConnectionMessageDisplay.module.css
+++ b/src/features/connection/components/connection-message-display/ConnectionMessageDisplay.module.css
@@ -29,13 +29,9 @@
 }
 
 .loading-indicator {
-	font-size: 1.125rem;
+	font-size: 1rem;
 
 	@media (width < 768px) {
-		font-size: 1rem;
-	}
-
-	@media (width < 640px) {
 		font-size: 0.875rem;
 	}
 }

--- a/src/features/connection/components/connection-page-client/ConnectionPageClient.module.css
+++ b/src/features/connection/components/connection-page-client/ConnectionPageClient.module.css
@@ -106,13 +106,9 @@
 }
 
 .loading-indicator {
-	font-size: 1.125rem;
+	font-size: 1rem;
 
 	@media (width < 768px) {
-		font-size: 1rem;
-	}
-
-	@media (width < 640px) {
 		font-size: 0.875rem;
 	}
 }

--- a/src/features/connection/components/connection-zenn-form/ConnectionZennForm.module.css
+++ b/src/features/connection/components/connection-zenn-form/ConnectionZennForm.module.css
@@ -41,13 +41,9 @@
 }
 
 .loading-indicator {
-	font-size: 1.125rem;
+	font-size: 1rem;
 
 	@media (width < 768px) {
-		font-size: 1rem;
-	}
-
-	@media (width < 640px) {
 		font-size: 0.875rem;
 	}
 }

--- a/src/features/explore/components/explore-page-client/ExplorePageClient.module.css
+++ b/src/features/explore/components/explore-page-client/ExplorePageClient.module.css
@@ -197,14 +197,14 @@
 	}
 }
 
-.loading-indicator {
-	font-size: 1.125rem;
+.btn-loading-indicator {
+	font-size: 0.875rem;
+}
+
+.content-loading-indicator {
+	font-size: 1rem;
 
 	@media (width < 768px) {
-		font-size: 1rem;
-	}
-
-	@media (width < 640px) {
 		font-size: 0.875rem;
 	}
 }

--- a/src/features/explore/components/explore-page-client/ExplorePageClient.tsx
+++ b/src/features/explore/components/explore-page-client/ExplorePageClient.tsx
@@ -24,7 +24,7 @@ const ExploreArticleAnalysis = dynamic(
 					height: "100%",
 				}}
 			>
-				<LoadingIndicator text="読み込み中" className={styles["loading-indicator"]} />
+				<LoadingIndicator text="読み込み中" className={styles["content-loading-indicator"]} />
 			</div>
 		),
 	}
@@ -129,7 +129,7 @@ const ExplorePageClient = ({ initialZennUsername }: Props) => {
 
 					{!isLoaded ? (
 						<div className="grid place-items-center px-4">
-							<LoadingIndicator text="読み込み中" className={styles["loading-indicator"]} />
+							<LoadingIndicator text="読み込み中"  className={styles["btn-loading-indicator"]} />
 						</div>
 					) : !isGuestUser ? (
 						<div className={styles["explore-analysis-controls"]}>

--- a/src/features/strength/components/strength-log-info-skeleton/StrengthLogInfoSkeleton.module.css
+++ b/src/features/strength/components/strength-log-info-skeleton/StrengthLogInfoSkeleton.module.css
@@ -87,13 +87,9 @@
 }
 
 .loading-indicator {
-	font-size: 1.125rem;
+	font-size: 1rem;
 
 	@media (width < 768px) {
-		font-size: 1rem;
-	}
-
-	@media (width < 640px) {
 		font-size: 0.875rem;
 	}
 }

--- a/src/features/title/components/title-page-client/TitlePageClient.module.css
+++ b/src/features/title/components/title-page-client/TitlePageClient.module.css
@@ -53,13 +53,9 @@
 }
 
 .loading-indicator {
-	font-size: 1.125rem;
+	font-size: 1rem;
 
 	@media (width < 768px) {
-		font-size: 1rem;
-	}
-
-	@media (width < 640px) {
 		font-size: 0.875rem;
 	}
 }


### PR DESCRIPTION
## Summary

- `font-size: 1.125rem` → `1rem` に統一
- 640px のメディアクエリを削除し 768px のみに
- ExplorePageClient の `loading-indicator` を用途別に分離

## 変更ファイル (8件)

| ファイル | 変更内容 |
|----------|----------|
| ConnectionAuthSection.module.css | フォントサイズ統一 |
| ConnectionMessageDisplay.module.css | フォントサイズ統一 |
| ConnectionPageClient.module.css | フォントサイズ統一 |
| ConnectionZennForm.module.css | フォントサイズ統一 |
| ExplorePageClient.module.css | クラス名分離 |
| ExplorePageClient.tsx | クラス名変更 |
| StrengthLogInfoSkeleton.module.css | フォントサイズ統一 |
| TitlePageClient.module.css | フォントサイズ統一 |

## Test plan

- [x] 各ページの LoadingIndicator が正常に表示されることを確認
- [x] レスポンシブ対応が正常に動作することを確認

Closes #172