### PR TITLE
fix: follow camoneart -> kaijutale rename (contact + GitHub URLs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ OUTPUT QUESTのプライバシーポリシーを確認できます。
 
 <h2 id="development-configuration-diagram">開発構成図</h2>
 
-[開発構成図](https://camoneart.github.io/outputquest-development-configuration-diagram/)はHTMLインフォグラフィックで表現しました。
+[開発構成図](https://kaijutale.github.io/outputquest-development-configuration-diagram/)はHTMLインフォグラフィックで表現しました。
 
 <h2 id="directory-design">ディレクトリ構造</h2>
 
@@ -424,8 +424,8 @@ outputquest/
 ### 1. リポジトリのクローン
 
 ```bash
-git clone https://github.com/camoneart/output-quest.git
-cd output-quest
+git clone https://github.com/kaijutale/outputquest.git
+cd outputquest
 ```
 
 ### 2. パッケージのインストール

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"homepage": "https://outputquest.com",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/camoneart/output-quest"
+		"url": "https://github.com/kaijutale/outputquest"
 	},
 	"packageManager": "pnpm@10.11.1",
 	"engines": {

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -92,7 +92,7 @@ const PrivacyPage = () => {
 										<dt className="md:text-base text-sm">開発者のメールアドレス：</dt>
 										<dd>
 											<SafeMailtoLink
-												user="camoneart"
+												user="taleofkaiju"
 												domain="gmail.com"
 												className="md:text-base text-sm underline underline-offset-4 py-1 pr-2"
 											/>
@@ -102,12 +102,12 @@ const PrivacyPage = () => {
 										<dt className="md:text-base text-sm">開発者のX：</dt>
 										<dd>
 											<Link
-												href="https://x.com/camoneart"
+												href="https://x.com/kaijutale"
 												className="md:text-base text-sm underline underline-offset-4 py-1 pr-2"
 												target="_blank"
 												rel="noopener noreferrer"
 											>
-												@camoneart
+												@kaijutale
 											</Link>
 										</dd>
 									</div>


### PR DESCRIPTION
## 概要

GitHub アカウント改名 (camoneart -> kaijutale) に追従し、リポジトリ内の連絡先と GitHub URL を更新する。GitHub Web 改名は 2026-06-02 完了済み。

## 変更内容

### A群 (0b67478) X/Gmail 連絡先 — `src/app/(main)/privacy/page.tsx`
- メール user: `camoneart` -> `taleofkaiju` (= taleofkaiju@gmail.com)
- X: `@camoneart` -> `@kaijutale`

### B群 (2e8ee70) GitHub URL
- `package.json` repository.url -> `github.com/kaijutale/outputquest`
- `README.md` 開発構成図リンク -> `kaijutale.github.io/...`
- `README.md` clone URL / `cd` -> `outputquest` (実 remote に合わせハイフンなし)

## 補足

- `package.json` の `"name": "output-quest"` はパッケージ識別子 (URL ではない) のため据え置き
- リポジトリ名は実 remote (`git@github.com:kaijutale/outputquest.git`) に合わせ `outputquest` (ハイフンなし) で確定
- 検証: package.json JSON 妥当性 / camoneart 残存 grep (clean) / 差分目視。ビルドは未実行 (静的文字列のみの差分)