### PR TITLE
fix(security): replace Math.random with crypto.randomUUID (CodeQL js/insecure-randomness)

### DIFF
--- a/src/app/api/zenn/route.ts
+++ b/src/app/api/zenn/route.ts
@@ -68,7 +68,7 @@ const fetchWithTimeoutAndRetry = async (
 			if (bustCache || attempt > 1) {
 				const separator = url.includes("?") ? "&" : "?";
 				const timestamp = Date.now();
-				const randomId = Math.random().toString(36).substring(2, 15);
+				const randomId = crypto.randomUUID();
 				fetchUrl = `${url}${separator}_t=${timestamp}&_retry=${attempt}&_r=${randomId}`;
 			}
 

--- a/src/features/connection/_actions/zennConnection.ts
+++ b/src/features/connection/_actions/zennConnection.ts
@@ -81,7 +81,7 @@ const fetchZennArticles = async (
 }> => {
 	try {
 		const timestamp = Date.now();
-		const randomId = Math.random().toString(36).substring(2, 15);
+		const randomId = crypto.randomUUID();
 		const apiUrl = `https://zenn.dev/api/articles?username=${encodeURIComponent(username)}&_t=${timestamp}&_r=${randomId}`;
 
 		const response = await fetchWithTimeout(apiUrl);
@@ -177,7 +177,7 @@ export async function connectZenn(
 
 		// 4. 疑わしい固定カウントチェック（APIバグ対策）
 		if (zennResponse.totalCount === SUSPICIOUS_FIXED_COUNT) {
-			const randomUsername = `test_${Math.random().toString(36).substring(2, 10)}`;
+			const randomUsername = `test_${crypto.randomUUID().slice(0, 8)}`;
 			const testResponse = await fetchZennArticles(randomUsername);
 
 			if (testResponse.success && testResponse.totalCount === SUSPICIOUS_FIXED_COUNT) {
@@ -331,7 +331,7 @@ export async function syncZennArticles(zennUsername: string): Promise<ZennConnec
 
 		// 疑わしい固定カウントチェック
 		if (zennResponse.totalCount === SUSPICIOUS_FIXED_COUNT) {
-			const randomUsername = `test_${Math.random().toString(36).substring(2, 10)}`;
+			const randomUsername = `test_${crypto.randomUUID().slice(0, 8)}`;
 			const testResponse = await fetchZennArticles(randomUsername);
 
 			if (testResponse.success && testResponse.totalCount === SUSPICIOUS_FIXED_COUNT) {


### PR DESCRIPTION
## 概要

CodeQL の HIGH アラート `js/insecure-randomness` を解消するため、`Math.random()` を暗号学的に安全な `crypto.randomUUID()`（Web Crypto API）へ全置換した。

## 変更内容

`Math.random().toString(36).substring(...)` を使っていた箇所を `crypto.randomUUID()` に統一（src 内の `Math.random()` は 0 件に）。

| ファイル | 箇所 | 用途 |
|----------|------|------|
| `src/features/connection/_actions/zennConnection.ts` | 3 | キャッシュバスター `_r=` / 疑わしいカウント検出用プローブ名 (connectZenn・syncZennArticles) |
| `src/app/api/zenn/route.ts` | 1 | リトライ時のキャッシュバスター `_r=` |

## なぜ

- CodeQL default setup が `js/insecure-randomness` (HIGH) を 1 件検出（report 箇所: `zennConnection.ts`）
- これらの乱数はトークン・セッション・暗号鍵には使われておらず（キャッシュバスター + 存在しないユーザー名の探索プローブ）、実害のある脆弱性ではない
- ただし `crypto.randomUUID()` への置換は厳密に上位互換でデメリットがなく、HIGH アラートを解消しセキュリティダッシュボードをクリーンにできるため対応

## 検証

- `pnpm format:check`: green（CI blocking パス）
- 変更ファイルの `tsc --noEmit` / `eslint`: エラーゼロ
- `crypto` は Node 20+ / Next.js server action で global 利用可能（追加 import なし）

## スコープ外

- Dependabot 依存脆弱性（別 PR 群 #185〜#193 で対応予定）
- 既存の png インポート型エラー（Next の型拡張依存・Vercel ビルドは通過）