### PR TITLE
fix(security): bump @clerk/types to 4.101.25 to resolve vulnerable @clerk/shared@3.42.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@ai-sdk/google": "3.0.80",
 		"@ai-sdk/react": "3.0.197",
 		"@clerk/nextjs": "6.39.3",
-		"@clerk/types": "4.101.10",
+		"@clerk/types": "4.101.25",
 		"@google/generative-ai": "0.24.1",
 		"@phosphor-icons/react": "2.1.10",
 		"@prisma/adapter-pg": "7.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: 6.39.3
         version: 6.39.3(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@clerk/types':
-        specifier: 4.101.10
-        version: 4.101.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 4.101.25
+        version: 4.101.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@google/generative-ai':
         specifier: 0.24.1
         version: 0.24.1
@@ -281,18 +281,6 @@ packages:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
 
-  '@clerk/shared@3.42.0':
-    resolution: {integrity: sha512-sJUur/7jnHHlAsdoDosxpOmfV05VR7K5rvqlFskj3GaAMFEJrvdOztw0hmhBGVSWiCpjTZfdGITegton8mo7mQ==}
-    engines: {node: '>=18.17.0'}
-    peerDependencies:
-      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
-      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   '@clerk/shared@3.47.7':
     resolution: {integrity: sha512-9Yv4MJFEaC7BzV0whxa4txQ4SoMu/3j1LBnI85EBykb5CcfXxIKvNX/9sjMUUySHlTOjsj7XZa5i3W5Dx02K/Q==}
     engines: {node: '>=18.17.0'}
@@ -304,11 +292,6 @@ packages:
         optional: true
       react-dom:
         optional: true
-
-  '@clerk/types@4.101.10':
-    resolution: {integrity: sha512-qlmgnAm/IeK02RKEKVN8/Glx07xw/Lcv67jBfikM8HXhHc5v7bfYLD8UiWTr6H2RGtvB09cIt9JezRRlsuVBew==}
-    engines: {node: '>=18.17.0'}
-    deprecated: 'This package is no longer supported. Please import types from @clerk/shared/types instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
 
   '@clerk/types@4.101.25':
     resolution: {integrity: sha512-gPxm3hlBkP7B9EfKyp3/UDonNOjg7Z0UvqfrMj5u8gA8nyzvC1UFYtSTTmTfgSY82+5Yo38YV0DYu9vNf6t9CQ==}
@@ -2016,10 +1999,6 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
-
   js-cookie@3.0.7:
     resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
     engines: {node: '>=20'}
@@ -3194,18 +3173,6 @@ snapshots:
       server-only: 0.0.1
       tslib: 2.8.1
 
-  '@clerk/shared@3.42.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      csstype: 3.1.3
-      dequal: 2.0.3
-      glob-to-regexp: 0.4.1
-      js-cookie: 3.0.5
-      std-env: 3.10.0
-      swr: 2.3.4(react@19.2.7)
-    optionalDependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@clerk/shared@3.47.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       csstype: 3.1.3
@@ -3217,13 +3184,6 @@ snapshots:
     optionalDependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-
-  '@clerk/types@4.101.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@clerk/shared': 3.42.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-    transitivePeerDependencies:
-      - react
-      - react-dom
 
   '@clerk/types@4.101.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -5007,8 +4967,6 @@ snapshots:
       set-function-name: 2.0.2
 
   jiti@2.7.0: {}
-
-  js-cookie@3.0.5: {}
 
   js-cookie@3.0.7: {}
 


### PR DESCRIPTION
## 概要

直接依存 `@clerk/types` を 4.101.10 → 4.101.25 に上げ、推移依存として残っていた脆弱な `@clerk/shared@3.42.0` を依存ツリーから除去する。

## 背景（なぜ #195 だけでは不十分だったか）

#195 で `@clerk/nextjs` を 6.39.3 に上げ、@clerk/nextjs 由来の Critical（ミドルウェアのルート保護バイパス）と High（認可バイパス）は解消した。しかし lockfile には **脆弱な `@clerk/shared@3.42.0` が別経路で残存**していた。

```
@clerk/nextjs@6.39.3  -> @clerk/shared@3.47.7  (パッチ済)
@clerk/types@4.101.10 -> @clerk/shared@3.42.0  (脆弱: < 3.47.4)  <- 残存していた経路
```

`@clerk/types@4.101.25` は `@clerk/shared@3.47.7`（パッチ済）に依存しており、かつ既に @clerk/nextjs@6.39.3 の依存ツリーで使われている実績のあるバージョンのため、これに揃えることで重複していた 3.42.0 のサブツリーが除去される。

## 解消されるアラート

| パッケージ | 深刻度 | 内容 |
|-----------|--------|------|
| @clerk/shared | Critical | Middleware-based route protection bypass（patched ≥ 3.47.4） |
| @clerk/shared | High | Authorization bypass: org/billing/reverification（patched ≥ 3.47.5） |

## 変更内容

- `package.json`: `@clerk/types` 4.101.10 → 4.101.25（4.101.x 内の patch）
- `pnpm-lock.yaml`: 再生成（`pnpm install --lockfile-only`）。脆弱な `@clerk/shared@3.42.0` のサブツリーを削除（lockfile 上 @clerk/shared は 3.47.7 のみに）

## 検証

- `grep "@clerk/shared@3.42.0" pnpm-lock.yaml` → 0 件（除去確認）
- 残る @clerk/shared は 3.47.7（パッチ済）のみ
- 型互換性は Vercel ビルド（next build = 型チェック含む）で検証（4.101.x 内 patch のため低リスク）

## スコープ外

- 残りの Dependabot アラート（js-cookie / postcss[#196] / uuid）は別途対応
- dev-tooling メジャー更新（#192）は保留中