### PR TITLE
fix(security): override postcss to ^8.5.15 to resolve postcss@8.4.31 vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
 	"pnpm": {
 		"overrides": {
 			"@types/react": "19.2.16",
-			"@types/react-dom": "19.2.3"
+			"@types/react-dom": "19.2.3",
+			"postcss": "^8.5.15"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@types/react': 19.2.16
   '@types/react-dom': 19.2.3
+  postcss: ^8.5.15
 
 importers:
 
@@ -134,7 +135,7 @@ importers:
         specifier: 5.5.6
         version: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))(prettier@3.8.3)
       postcss:
-        specifier: 8.5.15
+        specifier: ^8.5.15
         version: 8.5.15
       prettier:
         specifier: 3.8.3
@@ -2445,10 +2446,6 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -5330,7 +5327,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.33
       caniuse-lite: 1.0.30001793
-      postcss: 8.4.31
+      postcss: 8.5.15
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
@@ -5498,12 +5495,6 @@ snapshots:
       pathe: 2.0.3
 
   possible-typed-array-names@1.1.0: {}
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.15:
     dependencies:


### PR DESCRIPTION
## 概要

pnpm.overrides に `postcss: ^8.5.15` を追加し、推移依存として残っていた脆弱な `postcss@8.4.31` を依存ツリーから除去する。

## 背景（なぜ通常の Dependabot PR では直せなかったか）

postcss medium アラート（XSS via unescaped `</style>` in CSS Stringify Output、patched ≥ 8.5.10）の対象 `postcss@8.4.31` は、**Next.js 自身が exact pin で依存**している（`next@16.2.7 -> postcss: 8.4.31`）。このため Dependabot の推移バンプ（PR #196）ではピンを上書きできず、アラートが解消されなかった。

`pnpm.overrides` で postcss を強制することで、Next の pin を含むツリー全体が 8.5.15 に揃う。プロジェクトの直接依存 postcss は既に 8.5.15（#191 で更新済）のため、override により単一バージョンに dedup される。

## 解消されるアラート

| パッケージ | 深刻度 | 内容 |
|-----------|--------|------|
| postcss | medium | XSS via Unescaped `</style>` in CSS Stringify Output（patched ≥ 8.5.10） |

## 変更内容

- `package.json`: `pnpm.overrides` に `"postcss": "^8.5.15"` を追加（^ で 8.x 内の将来パッチも許容）
- `pnpm-lock.yaml`: 再生成（`pnpm install --lockfile-only`）。`postcss@8.4.31` のサブツリーを削除し postcss は 8.5.15 のみに

## 検証

- `grep "postcss@8.4.31" pnpm-lock.yaml` → 0 件（除去確認）
- 残る postcss は 8.5.15（patched）のみ
- ビルド安全性は Vercel ビルド（next build）で検証。postcss 8.4.31→8.5.15 は 8.x 内 minor（後方互換）かつ Next は postcss の内部実装に依存しない

## スコープ外

- uuid（medium、svix@1.84.1 が pin）は svix の upstream 更新待ち（uuid v10→v11 override は svix 破壊リスクのため見送り）