### PR TITLE
docs(claude): Commandsにtestコマンド追加

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -33,6 +33,7 @@ src/config/       -- 環境設定
 dev:   `pnpm dev`
 build: `pnpm build`
 lint:  `pnpm lint:fix`
+test:  `pnpm test` (watch) / `pnpm test:run` (CI)
 db:    `pnpm prisma generate` / `pnpm prisma studio`
 
 ## Git


### PR DESCRIPTION
## 概要
authoring-claude-md skill (Review & Optimize Mode) で5原則評価。4.5/5.0 と高評価で、唯一の穴であった検証コマンド漏れを補完。スコア 4.5 → 5.0(想定)。

## 変更内容 (.claude/CLAUDE.md)
- Commands に test (pnpm test / pnpm test:run) を追加 — Vitest導入済みなのに検証手順に未記載だったため

## 検証
- validate-claude-md.sh: 6 PASS / 1 WARN(anti-anchor advisory) / 0 FAIL、48行