### PR TITLE
chore(rename): kaijutale を dendedev に統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ OUTPUT QUESTのプライバシーポリシーを確認できます。
 
 <h2 id="development-configuration-diagram">開発構成図</h2>
 
-[開発構成図](https://kaijutale.github.io/outputquest-development-configuration-diagram/)はHTMLインフォグラフィックで表現しました。
+[開発構成図](https://dendedev.github.io/outputquest-development-configuration-diagram/)はHTMLインフォグラフィックで表現しました。
 
 <h2 id="directory-design">ディレクトリ構造</h2>
 
@@ -424,7 +424,7 @@ outputquest/
 ### 1. リポジトリのクローン
 
 ```bash
-git clone https://github.com/kaijutale/outputquest.git
+git clone https://github.com/dendedev/outputquest.git
 cd outputquest
 ```
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"homepage": "https://outputquest.com",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/kaijutale/outputquest"
+		"url": "https://github.com/dendedev/outputquest"
 	},
 	"packageManager": "pnpm@10.11.1",
 	"engines": {

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -92,7 +92,7 @@ const PrivacyPage = () => {
 										<dt className="md:text-base text-sm">開発者のメールアドレス：</dt>
 										<dd>
 											<SafeMailtoLink
-												user="taleofkaiju"
+												user="ldendedevl"
 												domain="gmail.com"
 												className="md:text-base text-sm underline underline-offset-4 py-1 pr-2"
 											/>
@@ -102,12 +102,12 @@ const PrivacyPage = () => {
 										<dt className="md:text-base text-sm">開発者のX：</dt>
 										<dd>
 											<Link
-												href="https://x.com/kaijutale"
+												href="https://x.com/dendedev"
 												className="md:text-base text-sm underline underline-offset-4 py-1 pr-2"
 												target="_blank"
 												rel="noopener noreferrer"
 											>
-												@kaijutale
+												@dendedev
 											</Link>
 										</dd>
 									</div>

--- a/src/features/connection/utils/index.test.ts
+++ b/src/features/connection/utils/index.test.ts
@@ -3,27 +3,27 @@ import { cleanUsername, isValidZennUsernameFormat } from "./index";
 
 describe("cleanUsername", () => {
 	it("strips a single leading @", () => {
-		expect(cleanUsername("@kaiju")).toBe("kaiju");
+		expect(cleanUsername("@dende")).toBe("dende");
 	});
 
 	it("leaves a username without @ unchanged", () => {
-		expect(cleanUsername("kaiju")).toBe("kaiju");
+		expect(cleanUsername("dende")).toBe("dende");
 	});
 
 	it("only strips the leading @, not internal ones", () => {
-		expect(cleanUsername("@ka@iju")).toBe("ka@iju");
+		expect(cleanUsername("@de@nde")).toBe("de@nde");
 	});
 });
 
 describe("isValidZennUsernameFormat", () => {
-	it.each(["kaiju", "kaiju_123", "user-name", "ABC123", "_", "-"])(
+	it.each(["dende", "dende_123", "user-name", "ABC123", "_", "-"])(
 		"accepts valid username: %s",
 		(username) => {
 			expect(isValidZennUsernameFormat(username)).toBe(true);
 		}
 	);
 
-	it.each(["", "@kaiju", "kai ju", "かいじゅう", "user.name", "user!", "a/b"])(
+	it.each(["", "@dende", "den de", "デンデ", "user.name", "user!", "a/b"])(
 		"rejects invalid username: %s",
 		(username) => {
 			expect(isValidZennUsernameFormat(username)).toBe(false);

--- a/src/lib/cache-tags.test.ts
+++ b/src/lib/cache-tags.test.ts
@@ -9,7 +9,7 @@ describe("CacheTags", () => {
 	});
 
 	it("zennArticles() returns zenn-{username}", () => {
-		expect(CacheTags.zennArticles("kaiju")).toBe("zenn-kaiju");
+		expect(CacheTags.zennArticles("dende")).toBe("zenn-dende");
 	});
 
 	it("dashboard() returns dashboard-{clerkId}", () => {


### PR DESCRIPTION
## Summary

GitHub アカウントのリネーム (`kaijutale` → `dendedev`) に伴い、リポジトリ内の識別子表記を統一した。あわせて連絡先メールアドレスと X アカウントの参照も更新している。

差分は 5 ファイル / 12 行。ロジックの変更はなく、すべて文字列リテラルの置換。

## Changes

### アカウント参照の更新

- `package.json` — repository URL を `github.com/dendedev/outputquest` へ
- `README.md` — clone URL と開発構成図 (GitHub Pages) の URL を `dendedev` へ
- `src/app/(main)/privacy/page.tsx` — X アカウントを `@dendedev` へ、連絡先メールアドレスを `ldendedevl@gmail.com` へ

### テストのダミーユーザー名の統一

- `src/lib/cache-tags.test.ts` — `kaiju` → `dende`
- `src/features/connection/utils/index.test.ts` — `kaiju` → `dende`、`かいじゅう` → `デンデ`

単純な文字列置換ではヒットしない派生形も、同じダミー名の変種として統一した:

| 変更前 | 変更後 | テストの検証意図 |
|---|---|---|
| `@ka@iju` → `ka@iju` | `@de@nde` → `de@nde` | 先頭の `@` のみ除去し内部の `@` は保持 |
| `kai ju` | `den de` | スペースを含む名前を無効と判定 |

いずれも構造 (内部の `@` / スペースの位置) を保っているため、テストの検証内容は変わらない。

### 意図的に変更しなかったもの

`.docs/logs/local/`、`.docs/plans/archived/`、`.claude/handoff-state.md` に計 56 箇所の該当があるが、いずれも過去の作業記録のため変更していない。

とくに `2026-06-02_rename-camoneart-to-kaijutale.md` は「`camoneart` → `kaijutale` のリネーム作業」そのものの記録であり、書き換えると当時の事実が失われる。

## Test Plan

- [x] `pnpm test:run` — **52 tests passed (7 files)**
- [x] 残存確認 — Git 管理対象に `kaiju` / `かいじゅう` の残存 **0 件**
- [x] `dendedev/outputquest` への到達確認 (`git ls-remote`)
- [x] 構成図リポジトリの実在確認 (`gh api` → `has_pages=true`)
- [x] GitHub Pages URL の到達確認 — `dendedev.github.io/outputquest-development-configuration-diagram/` が正常応答
- [x] ローカル dev サーバーで `/privacy` の表示確認

### 検証できなかった項目

- **X アカウント `@dendedev` の実在** — `x.com` が HTTP 402 を返すため機械的に確認できていない
- **lint** — `eslint-plugin-react@7.37.5` が ESLint 10.4.1 と非互換で実行不能 (`contextOrFilename.getFilename is not a function`)。未変更ファイルでも同じ例外が出るため本 PR とは無関係な既存の環境問題

## Breaking Changes

なし

## Notes

- `git remote` の URL も `git@github.com:dendedev/outputquest.git` へ更新済み。ローカル設定のため本 PR の差分には含まれない
