### PR TITLE
fix(security): postcss の overrides を 8.5.23 に固定

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"overrides": {
 			"@types/react": "19.2.16",
 			"@types/react-dom": "19.2.3",
-			"postcss": "^8.5.23"
+			"postcss": "8.5.23"
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"overrides": {
 			"@types/react": "19.2.16",
 			"@types/react-dom": "19.2.3",
-			"postcss": "^8.5.15"
+			"postcss": "^8.5.23"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@types/react': 19.2.16
   '@types/react-dom': 19.2.3
-  postcss: ^8.5.15
+  postcss: ^8.5.23
 
 importers:
 
@@ -138,8 +138,8 @@ importers:
         specifier: 20.10.1
         version: 20.10.1
       postcss:
-        specifier: ^8.5.15
-        version: 8.5.15
+        specifier: ^8.5.23
+        version: 8.5.23
       prettier:
         specifier: 3.8.3
         version: 3.8.3
@@ -2665,11 +2665,6 @@ packages:
     resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
     engines: {node: '>=8.0.0'}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2848,10 +2843,6 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
-
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
@@ -4281,7 +4272,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.15
+      postcss: 8.5.23
       tailwindcss: 4.3.0
 
   '@tybys/wasm-util@0.10.2':
@@ -6243,8 +6234,6 @@ snapshots:
     dependencies:
       lru.min: 1.1.4
 
-  nanoid@3.3.12: {}
-
   nanoid@3.3.16: {}
 
   napi-postinstall@0.3.4: {}
@@ -6431,12 +6420,6 @@ snapshots:
       pathe: 2.0.3
 
   possible-typed-array-names@1.1.0: {}
-
-  postcss@8.5.15:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.23:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@types/react': 19.2.16
   '@types/react-dom': 19.2.3
-  postcss: ^8.5.23
+  postcss: 8.5.23
 
 importers:
 
@@ -138,7 +138,7 @@ importers:
         specifier: 20.10.1
         version: 20.10.1
       postcss:
-        specifier: ^8.5.23
+        specifier: 8.5.23
         version: 8.5.23
       prettier:
         specifier: 3.8.3


### PR DESCRIPTION
## Summary

`pnpm.overrides` の `postcss` が `^8.5.15` を指定しており、`devDependencies` で `8.5.23` を指定しているにもかかわらず、実際には脆弱性のある `8.5.15` が解決されていた。overrides を `8.5.23` に引き上げて解消する。

これにより Dependabot alert 2 件（high 1 / medium 1）が解消される見込み。

## 背景

#229 で破損した lockfile を再生成した際、`pnpm` は `pnpm.overrides` の `^8.5.15` を満たす範囲で解決した結果、`postcss@8.5.15` を採用していた。

| lockfile | postcss の解決結果 |
|---|---|
| `60a691e`（破損状態） | `8.5.23` / `8.5.25` |
| `2319c11`（#229 修復後） | **`8.5.15`** / `8.5.23` |
| 本 PR | **`8.5.23` のみ** |

`devDependencies` は #227 で `8.5.23` に更新済みだったが、`overrides` の下限指定が古いままだったため、推移的依存として引き込まれる `postcss` が古いバージョンに留まっていた。

対象の alert:

| 深刻度 | パッケージ | first_patched_version |
|---|---|---|
| high | postcss | 8.5.18 |
| medium | postcss | 8.5.23 |

## 修正内容

`package.json` の 1 行のみ:

```diff
 "overrides": {
   "@types/react": "19.2.16",
   "@types/react-dom": "19.2.3",
-  "postcss": "^8.5.15"
+  "postcss": "8.5.23"
 }
```

lockfile は `pnpm install` により追随。

### バージョン表記について

本リポジトリの `package.json` は**全依存を固定バージョンで指定**する方針を取っている。`dependencies` / `devDependencies` / `overrides` を通じて範囲指定 (`^` / `~`) は 1 件も使われておらず、`postcss` の `^8.5.15` が唯一の例外だった。

範囲指定は「下限が古いまま放置されると、上位バージョンが利用可能でも古い方が解決されうる」という今回の取り残しを生む。既存パターンに合わせて固定表記に統一する。

修正後の `overrides` は 3 件すべてが固定表記で揃う:

```json
"overrides": {
  "@types/react": "19.2.16",
  "@types/react-dom": "19.2.3",
  "postcss": "8.5.23"
}
```

## Test Plan

CI (`.github/workflows/ci.yml`) と同一のコマンドで検証した。

- [x] lockfile 内の `postcss` — **`8.5.23` のみ**（`8.5.15` は消滅）
- [x] セクション内の重複キー — **0 箇所**
- [x] `pnpm install --frozen-lockfile --ignore-scripts` — **成功**
- [x] `pnpm format:check` — **All matched files use Prettier code style!**
- [x] `pnpm test:run` — **52 passed (7 files)**

## Breaking Changes

なし。`postcss` はビルド時のみ使用される devDependency であり、パッチバージョンの引き上げのみ。

## 残存する脆弱性（本 PR の対象外）

本 PR 適用後も 8 件が残る。いずれも推移的依存であり、`pnpm.overrides` での個別対応が必要になる。互換性リスクがあるため、1 件ずつ検証しながら進めるのが妥当と考える。

| 深刻度 | パッケージ | 現バージョン | fix |
|---|---|---|---|
| high | `fast-uri` ×3 | 3.1.2 | 3.1.3 / 3.1.4 / 3.1.5 |
| high | `brace-expansion` ×2 | 1.1.15 / 5.0.6 | 1.1.16 / 5.0.7 |
| high | `sharp` | 0.34.5 | 0.35.0 |
| high | `js-yaml` | 4.2.0 | 4.3.0 |
| medium | `uuid` | 10.0.0 | 11.1.1 |

## 参考: lint 破損の根本原因（本 PR では修正しない）

`pnpm install` 実行時に、以下の peer dependency 不一致が報告された。

```
eslint-plugin-react 7.37.5
  └── ✕ unmet peer eslint@"^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7": found 10.4.1
```

`eslint-config-next@16.2.7` が引き込む `eslint-plugin-react@7.37.5` は ESLint 9.7 までしかサポートしておらず、現在の `eslint@10.4.1` とは非互換。これが `pnpm lint` の `TypeError: contextOrFilename.getFilename is not a function` の原因である。

`ci.yml` の lint ステップは `continue-on-error: true` のため、この失敗は CI 上で緑として記録される。
