### PR TITLE
docs(readme): 技術スタックのバージョン記載を実際の値に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,23 +192,23 @@ OUTPUT QUESTのプライバシーポリシーを確認できます。
 
 ### nodeバージョン
 
-- [node](https://nodejs.org/ja/)：v24.8.0
+- [node](https://nodejs.org/ja/)：v24.13.1
 - [pnpm](https://pnpm.io/ja/)：v10.11.1
 
 ### フロント
 
-- [Next.js(App Router)](https://nextjs.org)：v16.1.1
-- [React](https://react.dev)：v19.2.3
-- [TypeScript](https://www.typescriptlang.org/)：v5.9.3
+- [Next.js(App Router)](https://nextjs.org)：v16.2.11
+- [React](https://react.dev)：v19.2.7
+- [TypeScript](https://www.typescriptlang.org/)：v6.0.3
 
 ### スタイル・UI
 
-- [Tailwind CSS](https://tailwindcss.com/)：v4.1.18
+- [Tailwind CSS](https://tailwindcss.com/)：v4.3.0
 - [shadcn/ui](https://ui.shadcn.com/)
 
 ### アニメーション
 
-- [Motion](https://motion.dev/)：v12.25.0
+- [Motion](https://motion.dev/)：v12.40.0
 
 ### オーディオ
 
@@ -216,19 +216,19 @@ OUTPUT QUESTのプライバシーポリシーを確認できます。
 
 ### 認証・データベース
 
-- [Clerk](https://clerk.com/)：v6.36.7（認証）
-- [Prisma](https://www.prisma.io/)：v7.2.0（ORM）
+- [Clerk](https://clerk.com/)：v6.39.3（認証）
+- [Prisma](https://www.prisma.io/)：v7.9.1（ORM）
 - [Supabase](https://supabase.com/)（PostgreSQL）
 
 ### スキーマバリデーション
 
-- [zod](https://zod.dev/)：v4.3.5
+- [zod](https://zod.dev/)：v4.4.3
 
 ### AI
 
-- [Vercel AI SDK](https://ai-sdk.dev/)：v6.0.24（TypeScript Toolkit）
-- [AI SDK Core](https://ai-sdk.dev/docs/ai-sdk-core/overview)：v3.0.6（LLM：Gemini(gemini-2.5-pro)）
-- [AI SDK UI](https://ai-sdk.dev/docs/ai-sdk-ui/overview)：v3.0.25（UI）
+- [Vercel AI SDK](https://ai-sdk.dev/)：v6.0.195（TypeScript Toolkit）
+- [AI SDK Core](https://ai-sdk.dev/docs/ai-sdk-core/overview)：v3.0.80（LLM：Gemini(gemini-2.5-pro)）
+- [AI SDK UI](https://ai-sdk.dev/docs/ai-sdk-ui/overview)：v3.0.197（UI）
 
 ### Markdown
 
@@ -417,7 +417,7 @@ outputquest/
 
 ### 前提条件
 
-- Node.js 20.9.0 以上
+- Node.js 20.19.0 以上
 - pnpm
 - Git
 


### PR DESCRIPTION
## Summary

README の技術スタックに記載されたバージョンが、`package.json` の実際の値と乖離していた。13 箇所を実際の値に更新する。

乖離は今回の依存更新（#223 / #228 / #227 / #230）で生じたものだけではなく、それ以前から蓄積していた。TypeScript はメジャーバージョンがずれていた（README: v5.9.3 / 実際: 6.0.3）。

## Changes

### ライブラリのバージョン（`package.json` が正）

| 行 | ライブラリ | 変更前 | 変更後 |
|---|---|---|---|
| 200 | Next.js | v16.1.1 | **v16.2.11** |
| 201 | React | v19.2.3 | **v19.2.7** |
| 202 | TypeScript | v5.9.3 | **v6.0.3** |
| 206 | Tailwind CSS | v4.1.18 | **v4.3.0** |
| 211 | Motion | v12.25.0 | **v12.40.0** |
| 219 | Clerk | v6.36.7 | **v6.39.3** |
| 220 | Prisma | v7.2.0 | **v7.9.1** |
| 225 | zod | v4.3.5 | **v4.4.3** |
| 229 | Vercel AI SDK | v6.0.24 | **v6.0.195** |
| 230 | AI SDK Core | v3.0.6 | **v3.0.80** |
| 231 | AI SDK UI | v3.0.25 | **v3.0.197** |

### Node.js の記載（2 箇所の役割を分離）

README には node に関する記載が 2 箇所あり、互いに食い違っていた。役割が異なるため、それぞれ別の値を正とした。

| 行 | 役割 | 変更前 | 変更後 | 根拠 |
|---|---|---|---|---|
| 195 | 開発環境の実バージョン | v24.8.0 | **v24.13.1** | `node --version` の実測値 |
| 420 | 動作要件（前提条件） | 20.9.0 以上 | **20.19.0 以上** | `package.json` の `engines.node: ">=20.19.0"` |

### 変更しなかったもの（既に一致）

- 196 行 pnpm v10.11.1 — `packageManager: "pnpm@10.11.1"` と一致
- 215 行 Howler.js v2.2.4
- 235 行 react-markdown v10.1.0

## Test Plan

- [x] 13 ライブラリすべてについて、README の記載と `package.json` の値を**機械的に照合**（目視ではなくスクリプトで比較）— 全件一致
- [x] `engines.node` と 420 行の記載が一致することを確認
- [x] `pnpm format:check` — **All matched files use Prettier code style!**

## Breaking Changes

なし。ドキュメントのみの変更で、コードには影響しない。
