### PR TITLE
chore(deps): Dependabot に eslint の major 更新を無視させる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@ updates:
       day: "monday"
     open-pull-requests-limit: 10
     versioning-strategy: "increase"
+    # eslint の major 更新のみ無視する(minor/patch は従来どおり受け取る)。
+    # 理由: eslint-config-next が引き込む eslint-plugin-react が ESLint 10 に未対応で、
+    # 10.x へ上げると `pnpm lint` が TypeError でクラッシュする (PR #232 で 9.39.5 へ戻した)。
+    # eslint-plugin-react の ESLint 10 対応版 (7.8.0) が安定リリースされたら本設定を見直す。
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
     groups:
       next:
         patterns:


### PR DESCRIPTION
## Summary

Dependabot が `eslint` の major 更新（10.x）を提案しないよう `ignore` を設定する。minor / patch 更新は従来どおり受け取る。

## 背景

PR #232 で `eslint` を `10.4.1` → `9.39.5` にダウングレードし、クラッシュしていた `pnpm lint` を復旧させた。

しかし現在 open の Dependabot PR #220（dev-tooling group）は `eslint` を `9.39.5` → `10.8.0` に更新する内容を含んでおり、**マージすると lint が再びクラッシュする**。

```
TypeError: Error while loading rule 'react/display-name':
  contextOrFilename.getFilename is not a function
```

根本原因は `eslint-config-next` が引き込む `eslint-plugin-react@7.37.5` が ESLint 10 に未対応であること。同プラグインの peer 要件は以下のとおりで、ESLint 10 が含まれていない。

```
"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
```

ESLint 10 対応版は `7.8.0-rc.0`（`next` タグ）のみで、安定版は未リリース。つまり**上流の対応待ち**であり、こちら側で ESLint 10 に上げられる状態にない。

設定を入れなければ、Dependabot は今後も繰り返し eslint 10.x への更新 PR を作り続け、そのたびに手動で除外する必要が生じる。

## 修正内容

`.github/dependabot.yml` に 7 行を追加（既存行の変更なし）:

```yaml
ignore:
  - dependency-name: "eslint"
    update-types: ["version-update:semver-major"]
```

`update-types: ["version-update:semver-major"]` を指定しているため、**major のみが対象**であり、9.x 系の minor / patch 更新は引き続き提案される。

### なぜ `exclude-patterns` ではなく `ignore` か

`dev-tooling` グループから `exclude-patterns` で `eslint` を外す方法も考えられるが、その場合 **eslint 単体の PR が別に作られ、やはり 10.x への更新が提案される**。グループ分けの問題ではなくバージョン range の問題であるため、`ignore` が適切と判断した。

## Test Plan

- [x] `python3` の YAML パーサで構文検証 — **パース成功**
- [x] 既存の 8 グループ（next / react / ai-sdk / clerk-auth / prisma-db / ui / styling / dev-tooling）が保持されていることを確認
- [x] `ignore` が `updates[0]` 直下の正しい階層に配置されていることを確認
- [x] 差分は追加 7 行のみ（既存行の変更なし）

## Breaking Changes

なし。CI やビルドには影響しない。Dependabot の PR 生成方針のみが変わる。

## 見直し条件

`eslint-plugin-react` の ESLint 10 対応版（`7.8.0`）が安定リリースされた時点で、本設定の削除を検討する。その旨は設定ファイル内のコメントにも記載した。

## 関連

- PR #232（ESLint を 9.39.5 に下げて lint を復旧）
- PR #220（dev-tooling group）— 本設定の適用後、Dependabot による再生成を想定
