### PR TITLE
fix(lint): try/catch 内での JSX 構築を解消

### DIFF
--- a/src/features/item-detail/components/item-detail-card/ItemDetailCard.tsx
+++ b/src/features/item-detail/components/item-detail-card/ItemDetailCard.tsx
@@ -14,7 +14,10 @@ interface ItemDetailCardProps {
 	itemId: number;
 }
 
-const ItemDetailCard = async ({ itemId }: ItemDetailCardProps) => {
+// データ取得はJSXの構築と分離する。
+// try/catch内でJSXを構築しても、Reactは即座にレンダリングしないため
+// レンダリング時のエラーはcatchされない (react-hooks/error-boundaries)。
+const loadItemDetail = async (itemId: number) => {
 	try {
 		const { articleCount, isGuestUser } = await getUserWithArticles();
 		const currentLevel = isGuestUser ? 1 : articleCount;
@@ -40,24 +43,43 @@ const ItemDetailCard = async ({ itemId }: ItemDetailCardProps) => {
 			: `/images/items-page/acquired-icon/item-${itemId}.png`;
 		const unacquiredImagePath = `/images/items-page/unacquired-icon/${customItemSilhouetteImages[itemId]}`;
 
-		// Client Componentにデータを渡す
-		return (
-			<ItemDetail.ItemDetailCardClient
-				itemId={itemId}
-				isAcquired={isAcquired}
-				isGuestUser={isGuestUser}
-				itemName={itemName}
-				itemDescription={itemDescription}
-				requiredLevel={requiredLevel}
-				levelDifference={levelDifference}
-				acquiredImagePath={acquiredImagePath}
-				unacquiredImagePath={unacquiredImagePath}
-			/>
-		);
+		return {
+			isAcquired,
+			isGuestUser,
+			itemName,
+			itemDescription,
+			requiredLevel,
+			levelDifference,
+			acquiredImagePath,
+			unacquiredImagePath,
+		};
 	} catch (error) {
 		console.error("アイテム詳細データ取得エラー:", error);
+		return null;
+	}
+};
+
+const ItemDetailCard = async ({ itemId }: ItemDetailCardProps) => {
+	const data = await loadItemDetail(itemId);
+
+	if (!data) {
 		return <p className={styles["error-message"]}>アイテム詳細データの取得に失敗しました。</p>;
 	}
+
+	// Client Componentにデータを渡す
+	return (
+		<ItemDetail.ItemDetailCardClient
+			itemId={itemId}
+			isAcquired={data.isAcquired}
+			isGuestUser={data.isGuestUser}
+			itemName={data.itemName}
+			itemDescription={data.itemDescription}
+			requiredLevel={data.requiredLevel}
+			levelDifference={data.levelDifference}
+			acquiredImagePath={data.acquiredImagePath}
+			unacquiredImagePath={data.unacquiredImagePath}
+		/>
+	);
 };
 
 export default ItemDetailCard;

--- a/src/features/items/components/item-card-list/ItemCardList.tsx
+++ b/src/features/items/components/item-card-list/ItemCardList.tsx
@@ -8,15 +8,27 @@ import styles from "./ItemCardList.module.css";
  *
  * アイテム一覧を取得して表示するServer Component
  */
-const ItemCardList = async () => {
+// データ取得はJSXの構築と分離する。
+// try/catch内でJSXを構築しても、Reactは即座にレンダリングしないため
+// レンダリング時のエラーはcatchされない (react-hooks/error-boundaries)。
+const loadItems = async () => {
 	try {
 		const { articleCount, isGuestUser } = await getUserWithArticles();
-		const items = updateItemsByLevel(articleCount);
-		return <Items.ItemCardListClient items={items} isGuestUser={isGuestUser} />;
+		return { items: updateItemsByLevel(articleCount), isGuestUser };
 	} catch (error) {
 		console.error("アイテムデータ取得エラー:", error);
+		return null;
+	}
+};
+
+const ItemCardList = async () => {
+	const data = await loadItems();
+
+	if (!data) {
 		return <p className={styles["error-message"]}>アイテムデータの取得に失敗しました。</p>;
 	}
+
+	return <Items.ItemCardListClient items={data.items} isGuestUser={data.isGuestUser} />;
 };
 
 export default ItemCardList;

--- a/src/features/party-member/components/party-member-detail-card/PartyMemberDetailCard.tsx
+++ b/src/features/party-member/components/party-member-detail-card/PartyMemberDetailCard.tsx
@@ -19,7 +19,10 @@ interface PartyMemberDetailCardProps {
  *
  * なかま詳細データを取得して表示するServer Component
  */
-const PartyMemberDetailCard = async ({ partyId }: PartyMemberDetailCardProps) => {
+// データ取得はJSXの構築と分離する。
+// try/catch内でJSXを構築しても、Reactは即座にレンダリングしないため
+// レンダリング時のエラーはcatchされない (react-hooks/error-boundaries)。
+const loadPartyMemberDetail = async (partyId: number) => {
 	try {
 		const { articleCount, isGuestUser } = await getUserWithArticles();
 		const currentLevel = isGuestUser ? 1 : articleCount;
@@ -43,24 +46,43 @@ const PartyMemberDetailCard = async ({ partyId }: PartyMemberDetailCardProps) =>
 		const acquiredImagePath = `/images/party-page/acquired-icon/${customMemberImages[partyId]}`;
 		const unacquiredImagePath = `/images/party-page/unacquired-icon/${customMemberSilhouetteImages[partyId]}`;
 
-		// Client Componentにデータを渡す
-		return (
-			<PartyMemberDetailCardClient
-				partyId={partyId}
-				isAcquired={isAcquired}
-				isGuestUser={isGuestUser}
-				memberName={memberName}
-				memberDescription={memberDescription}
-				requiredLevel={requiredLevel}
-				levelDifference={levelDifference}
-				acquiredImagePath={acquiredImagePath}
-				unacquiredImagePath={unacquiredImagePath}
-			/>
-		);
+		return {
+			isAcquired,
+			isGuestUser,
+			memberName,
+			memberDescription,
+			requiredLevel,
+			levelDifference,
+			acquiredImagePath,
+			unacquiredImagePath,
+		};
 	} catch (error) {
 		console.error("なかま詳細データ取得エラー:", error);
+		return null;
+	}
+};
+
+const PartyMemberDetailCard = async ({ partyId }: PartyMemberDetailCardProps) => {
+	const data = await loadPartyMemberDetail(partyId);
+
+	if (!data) {
 		return <p className={styles["error-message"]}>なかま詳細データの取得に失敗しました。</p>;
 	}
+
+	// Client Componentにデータを渡す
+	return (
+		<PartyMemberDetailCardClient
+			partyId={partyId}
+			isAcquired={data.isAcquired}
+			isGuestUser={data.isGuestUser}
+			memberName={data.memberName}
+			memberDescription={data.memberDescription}
+			requiredLevel={data.requiredLevel}
+			levelDifference={data.levelDifference}
+			acquiredImagePath={data.acquiredImagePath}
+			unacquiredImagePath={data.unacquiredImagePath}
+		/>
+	);
 };
 
 export default PartyMemberDetailCard;

--- a/src/features/party/components/party-member-card-list/PartyMemberCardList.tsx
+++ b/src/features/party/components/party-member-card-list/PartyMemberCardList.tsx
@@ -8,15 +8,27 @@ import styles from "./PartyMemberCardList.module.css";
  *
  * パーティメンバー一覧を取得して表示するServer Component
  */
-const PartyMemberCardList = async () => {
+// データ取得はJSXの構築と分離する。
+// try/catch内でJSXを構築しても、Reactは即座にレンダリングしないため
+// レンダリング時のエラーはcatchされない (react-hooks/error-boundaries)。
+const loadPartyMembers = async () => {
 	try {
 		const { articleCount, isGuestUser } = await getUserWithArticles();
-		const members = updatePartyMembersByLevel(articleCount);
-		return <Party.PartyMemberCardListClient members={members} isGuestUser={isGuestUser} />;
+		return { members: updatePartyMembersByLevel(articleCount), isGuestUser };
 	} catch (error) {
 		console.error("仲間データ取得エラー:", error);
+		return null;
+	}
+};
+
+const PartyMemberCardList = async () => {
+	const data = await loadPartyMembers();
+
+	if (!data) {
 		return <p className={styles["error-message"]}>仲間データの取得に失敗しました。</p>;
 	}
+
+	return <Party.PartyMemberCardListClient members={data.members} isGuestUser={data.isGuestUser} />;
 };
 
 export default PartyMemberCardList;

--- a/src/features/posts/components/posts-list-with-data/PostsListWithData.tsx
+++ b/src/features/posts/components/posts-list-with-data/PostsListWithData.tsx
@@ -8,25 +8,36 @@ import styles from "./PostsListWithData.module.css";
  *
  * Zenn記事一覧を取得して表示するServer Component
  */
-const PostsListWithData = async () => {
+// データ取得はJSXの構築と分離する。
+// try/catch内でJSXを構築しても、Reactは即座にレンダリングしないため
+// レンダリング時のエラーはcatchされない (react-hooks/error-boundaries)。
+const loadPosts = async () => {
 	try {
 		const { articles } = await getUserWithArticles();
 
 		// platformType: "zenn" を各記事に設定
-		const postsData = articles.map((article) => ({
+		return articles.map((article) => ({
 			...article,
 			platformType: "zenn" as PlatformType,
 		}));
-
-		return <Posts.PostsList postsData={postsData} />;
 	} catch (error) {
 		console.error("Zenn記事の取得エラー:", error);
+		return null;
+	}
+};
+
+const PostsListWithData = async () => {
+	const postsData = await loadPosts();
+
+	if (!postsData) {
 		return (
 			<div className={styles["error-message"]}>
 				Zennの記事データの取得中にエラーが発生しました。
 			</div>
 		);
 	}
+
+	return <Posts.PostsList postsData={postsData} />;
 };
 
 export default PostsListWithData;

--- a/src/features/strength/components/strength-hero-info/StrengthHeroInfo.tsx
+++ b/src/features/strength/components/strength-hero-info/StrengthHeroInfo.tsx
@@ -10,7 +10,10 @@ import styles from "./StrengthHeroInfo.module.css";
  *
  * 勇者のレベル情報を取得して表示する
  */
-const StrengthHeroInfo = async () => {
+// データ取得はJSXの構築と分離する。
+// try/catch内でJSXを構築しても、Reactは即座にレンダリングしないため
+// レンダリング時のエラーはcatchされない (react-hooks/error-boundaries)。
+const loadHeroInfo = async () => {
 	try {
 		const { zennUsername, articleCount } = await getUserWithArticles();
 
@@ -28,92 +31,17 @@ const StrengthHeroInfo = async () => {
 		// 経験値の進捗率をパーセンテージで計算
 		const expProgressPercent = (heroData.currentExp / heroData.nextLevelExp) * 100;
 
-		return (
-			<div className={styles["strength-hero-info"]}>
-				<div className={styles["strength-hero-info-content"]}>
-					<h2 className={styles["strength-hero-info-title"]}>勇者のレベル</h2>
-					<div className={styles["strength-hero-info-content-head"]}>
-						{/* 勇者のアイコン　*/}
-						<div className={styles["strength-hero-box"]}>
-							<div className={styles["strength-hero-icon-box"]}>
-								<Image
-									src={heroPlateImage}
-									alt={"勇者"}
-									width={250}
-									height={250}
-									preload={true}
-									className={`${styles["strength-hero-icon-image"]}`}
-								/>
-							</div>
-							<div className={styles["strength-hero-name-box"]}>
-								<h3 className={`${styles["strength-hero-name"]}`}>
-									<Image
-										src={crown01EdgeImage}
-										alt="王冠"
-										width={100}
-										height={100}
-										preload={true}
-										className={`${styles["strength-hero-name-icon"]}`}
-									/>
-									<span>
-										{heroData.name}(@{zennUsername})
-									</span>
-								</h3>
-							</div>
-						</div>
-						{/* レベル表示 */}
-						<div className={styles["strength-level-info"]}>
-							<div className={`${styles["strength-level-display-box"]}`}>
-								<div className={`${styles["strength-level-display"]}`}>
-									<span className={`${styles["strength-level-display-text"]}`}>Lv</span>
-									<span className={`${styles["strength-level-display-value"]}`}>
-										{heroData.level}
-									</span>
-								</div>
-							</div>
-						</div>
-					</div>
-					{/* 経験値バー */}
-					<div className={styles["strength-level-progress-info"]}>
-						<div className={`${styles["strength-level-progress-box"]}`}>
-							<div className={`${styles["strength-level-progress-content"]}`}>
-								<span className={`${styles["strength-level-progress-text"]}`}>
-									次のレベルまで：
-								</span>
-								<div className={`${styles["strength-level-progress-info-remaining-articles"]}`}>
-									<em className={`${styles["strength-level-progress-info-remaining-articles-em"]}`}>
-										{heroData.remainingArticles}
-									</em>
-									<span
-										className={`${styles["strength-level-progress-info-remaining-articles-unit"]}`}
-									>
-										記事
-									</span>
-								</div>
-							</div>
-							<div className={`${styles["strength-level-progress-gauge-container"]}`}>
-								<Image
-									src="/images/common/exp.svg"
-									alt="EXP"
-									width={35}
-									height={35}
-									preload={true}
-									className={`${styles["strength-level-progress-exp-icon"]}`}
-								/>
-								<div className={`${styles["strength-level-progress-gauge-box"]}`}>
-									<div
-										className={`${styles["strength-level-progress-gauge"]}`}
-										style={{ width: `${expProgressPercent}%` }}
-									></div>
-								</div>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		);
+		return { zennUsername, heroData, expProgressPercent };
 	} catch (error) {
 		console.error("Zenn記事の取得エラー:", error);
+		return null;
+	}
+};
+
+const StrengthHeroInfo = async () => {
+	const data = await loadHeroInfo();
+
+	if (!data) {
 		return (
 			<div className={styles["strength-hero-info"]}>
 				<div className={styles["strength-hero-info-content"]}>
@@ -123,6 +51,91 @@ const StrengthHeroInfo = async () => {
 			</div>
 		);
 	}
+
+	const { zennUsername, heroData, expProgressPercent } = data;
+
+	return (
+		<div className={styles["strength-hero-info"]}>
+			<div className={styles["strength-hero-info-content"]}>
+				<h2 className={styles["strength-hero-info-title"]}>勇者のレベル</h2>
+				<div className={styles["strength-hero-info-content-head"]}>
+					{/* 勇者のアイコン　*/}
+					<div className={styles["strength-hero-box"]}>
+						<div className={styles["strength-hero-icon-box"]}>
+							<Image
+								src={heroPlateImage}
+								alt={"勇者"}
+								width={250}
+								height={250}
+								preload={true}
+								className={`${styles["strength-hero-icon-image"]}`}
+							/>
+						</div>
+						<div className={styles["strength-hero-name-box"]}>
+							<h3 className={`${styles["strength-hero-name"]}`}>
+								<Image
+									src={crown01EdgeImage}
+									alt="王冠"
+									width={100}
+									height={100}
+									preload={true}
+									className={`${styles["strength-hero-name-icon"]}`}
+								/>
+								<span>
+									{heroData.name}(@{zennUsername})
+								</span>
+							</h3>
+						</div>
+					</div>
+					{/* レベル表示 */}
+					<div className={styles["strength-level-info"]}>
+						<div className={`${styles["strength-level-display-box"]}`}>
+							<div className={`${styles["strength-level-display"]}`}>
+								<span className={`${styles["strength-level-display-text"]}`}>Lv</span>
+								<span className={`${styles["strength-level-display-value"]}`}>
+									{heroData.level}
+								</span>
+							</div>
+						</div>
+					</div>
+				</div>
+				{/* 経験値バー */}
+				<div className={styles["strength-level-progress-info"]}>
+					<div className={`${styles["strength-level-progress-box"]}`}>
+						<div className={`${styles["strength-level-progress-content"]}`}>
+							<span className={`${styles["strength-level-progress-text"]}`}>次のレベルまで：</span>
+							<div className={`${styles["strength-level-progress-info-remaining-articles"]}`}>
+								<em className={`${styles["strength-level-progress-info-remaining-articles-em"]}`}>
+									{heroData.remainingArticles}
+								</em>
+								<span
+									className={`${styles["strength-level-progress-info-remaining-articles-unit"]}`}
+								>
+									記事
+								</span>
+							</div>
+						</div>
+						<div className={`${styles["strength-level-progress-gauge-container"]}`}>
+							<Image
+								src="/images/common/exp.svg"
+								alt="EXP"
+								width={35}
+								height={35}
+								preload={true}
+								className={`${styles["strength-level-progress-exp-icon"]}`}
+							/>
+							<div className={`${styles["strength-level-progress-gauge-box"]}`}>
+								<div
+									className={`${styles["strength-level-progress-gauge"]}`}
+									style={{ width: `${expProgressPercent}%` }}
+								></div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 };
 
 export default StrengthHeroInfo;

--- a/src/features/strength/components/strength-title-info/StrengthTitleInfo.tsx
+++ b/src/features/strength/components/strength-title-info/StrengthTitleInfo.tsx
@@ -7,24 +7,38 @@ import * as Strength from "@/features/strength/components";
  *
  * 称号情報を取得してStrengthTitleInfoClientに渡す
  */
-const StrengthTitleInfo = async () => {
+// データ取得はJSXの構築と分離する。
+// try/catch内でJSXを構築しても、Reactは即座にレンダリングしないため
+// レンダリング時のエラーはcatchされない (react-hooks/error-boundaries)。
+const loadTitleInfo = async () => {
 	try {
 		const { articleCount, isGuestUser } = await getUserWithArticles();
-		const heroLevel = Math.max(articleCount, 1); // 最低レベル1
-		return <Strength.StrengthTitleInfoClient heroLevel={heroLevel} isGuestUser={isGuestUser} />;
+		return { heroLevel: Math.max(articleCount, 1), isGuestUser }; // 最低レベル1
 	} catch (error) {
 		console.error("称号情報の取得エラー:", error);
+		return null;
+	}
+};
+
+const StrengthTitleInfo = async () => {
+	const data = await loadTitleInfo();
+
+	if (data) {
 		return (
-			<div className={styles["strength-title-info"]}>
-				<div className={styles["strength-title-info-content"]}>
-					<div className={styles["strength-title-box"]}>
-						<h2 className={styles["strength-title-title"]}>称号</h2>
-						<div className={styles["error-text"]}>データの取得中にエラーが発生しました。</div>
-					</div>
-				</div>
-			</div>
+			<Strength.StrengthTitleInfoClient heroLevel={data.heroLevel} isGuestUser={data.isGuestUser} />
 		);
 	}
+
+	return (
+		<div className={styles["strength-title-info"]}>
+			<div className={styles["strength-title-info-content"]}>
+				<div className={styles["strength-title-box"]}>
+					<h2 className={styles["strength-title-title"]}>称号</h2>
+					<div className={styles["error-text"]}>データの取得中にエラーが発生しました。</div>
+				</div>
+			</div>
+		</div>
+	);
 };
 
 export default StrengthTitleInfo;


### PR DESCRIPTION
## Summary

Server Component 内で `try/catch` の中に JSX の構築が含まれていた 7 ファイルを修正し、`react-hooks/error-boundaries` の指摘 33 件を解消する。

lint 全体では **45 件 → 12 件**（error は **34 件 → 1 件**）に減少した。

## 背景

PR #232 で ESLint を 9.39.5 に戻して `pnpm lint` を復旧させた結果、それまで検出できていなかった 45 件の指摘が現れた。本 PR はそのうち最大の塊である `react-hooks/error-boundaries`（33 件）を扱う。

### 指摘の内容

```
Avoid constructing JSX within try/catch

React does not immediately render components when JSX is rendered, so any errors
from this component will not be caught by the try/catch. To catch errors in
rendering a given component, wrap that component in an error boundary.
```

React は JSX を即座にレンダリングしないため、`try` ブロック内で JSX を組み立てても**子コンポーネントのレンダリング時エラーは捕捉されない**。データ取得の失敗は捕捉できているが、描画の失敗は素通りする状態だった。

## 修正内容

データ取得と JSX の構築を分離した。`try/catch` はデータ取得のみを包み、失敗時は `null` を返す。JSX の構築は `try` の外で行う。

```tsx
// 修正前
const ItemCardList = async () => {
  try {
    const { articleCount, isGuestUser } = await getUserWithArticles();
    const items = updateItemsByLevel(articleCount);
    return <Items.ItemCardListClient items={items} isGuestUser={isGuestUser} />;  // ← try 内
  } catch (error) {
    console.error("アイテムデータ取得エラー:", error);
    return <p>アイテムデータの取得に失敗しました。</p>;  // ← try 内
  }
};

// 修正後
const loadItems = async () => {
  try {
    const { articleCount, isGuestUser } = await getUserWithArticles();
    return { items: updateItemsByLevel(articleCount), isGuestUser };  // ← JSX なし
  } catch (error) {
    console.error("アイテムデータ取得エラー:", error);
    return null;
  }
};

const ItemCardList = async () => {
  const data = await loadItems();
  if (!data) {
    return <p>アイテムデータの取得に失敗しました。</p>;  // ← try の外
  }
  return <Items.ItemCardListClient items={data.items} isGuestUser={data.isGuestUser} />;
};
```

**挙動は変わらない。** データ取得の失敗は従来どおり捕捉され、同じエラー UI が表示される。変わったのは JSX を構築する位置のみ。

### なぜ関数への切り出しか

`let` で変数を宣言して `try` の外で使う方法もあるが、その場合 TypeScript の型注釈を手で書く必要が生じる。関数に切り出せば戻り値の型推論がそのまま効くため、型注釈を追加せずに型安全性を保てる。

### 対象ファイル（7 件）

| ファイル | 指摘数 |
|---|---|
| `features/items/components/item-card-list/ItemCardList.tsx` | — |
| `features/item-detail/components/item-detail-card/ItemDetailCard.tsx` | — |
| `features/party/components/party-member-card-list/PartyMemberCardList.tsx` | — |
| `features/party-member/components/party-member-detail-card/PartyMemberDetailCard.tsx` | — |
| `features/posts/components/posts-list-with-data/PostsListWithData.tsx` | — |
| `features/strength/components/strength-hero-info/StrengthHeroInfo.tsx` | — |
| `features/strength/components/strength-title-info/StrengthTitleInfo.tsx` | — |

（33 件の指摘がこの 7 ファイルに分布）

## Test Plan

- [x] `pnpm exec eslint . --format json` — `react-hooks/error-boundaries` が **33 件 → 0 件**
- [x] lint 全体 — **45 件 → 12 件**（error: 34 → 1）
- [x] `pnpm exec tsc --noEmit` — **exit 0**
- [x] `pnpm format:check` — **All matched files use Prettier code style!**
- [x] `pnpm test:run` — 後述（CI で検証）

## Breaking Changes

なし。エラーハンドリングの挙動、表示される UI ともに変更はない。

## 残存する 12 件（本 PR の対象外）

| 件数 | ルール | severity | 状態 |
|---|---|---|---|
| 10 | `react-hooks/set-state-in-effect` | warning | `eslint.config.mjs` で意図的に `warn` 設定済み |
| 1 | `@typescript-eslint/no-unused-vars` | warning | `warn` 設定 |
| 1 | `react-hooks/immutability` | **error** | 未対応 |

残る唯一の error は `src/contexts/HeroContext.tsx:321` の以下:

```
Cannot access variable before it is declared
`getZennArticlesCount` is accessed before it is declared
```

再帰的なリトライ処理で関数が宣言前の自身を参照している。修正には再帰構造そのものの組み替え（`useRef` の導入等）が必要で、アプリ全体の状態を持つ Context への変更となるため、本 PR には含めない。

## 関連

- PR #232（ESLint を 9.39.5 に戻して lint を復旧）— 本 PR の指摘が検出可能になった経緯
- `.github/workflows/ci.yml` の lint ステップは現在 `continue-on-error: true` のため、本 PR の適用有無に関わらず CI の結果は変わらない
