### PR TITLE
chore(ci): lint を blocking にする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,8 @@ jobs:
       - name: Format check
         run: pnpm format:check
 
-      - name: Lint (advisory, non-blocking)
+      - name: Lint
         run: pnpm lint
-        continue-on-error: true
 
   test:
     name: Test

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,13 @@ const eslintConfig = defineConfig([
 			// (GitHub Issue #34743). Set to "warn" to monitor for future improvements.
 			// Patterns like setMounted(true) in useEffect are officially recommended by React docs.
 			"react-hooks/set-state-in-effect": "warn",
+			// react-hooks/immutability: 現在1件の指摘が残っている
+			// (src/contexts/HeroContext.tsx の再帰リトライで getZennArticlesCount が宣言前に参照される)。
+			// set-state-in-effect と違い、これは誤検知ではなく実際の指摘。ただし修正には
+			// 再帰構造の組み替えが必要で、アプリ全体の状態を持つ Context への変更となるため、
+			// 認識した上で先送りする。lint を blocking 化するにあたり、既知の1件で
+			// ゲート全体を塞がないよう warn に落とす。修正後は error に戻すこと。
+			"react-hooks/immutability": "warn",
 			// Ignore unused variables that start with underscore (common convention for intentionally unused vars)
 			"@typescript-eslint/no-unused-vars": [
 				"warn",


### PR DESCRIPTION
## Summary

CI の lint ステップから `continue-on-error: true` を外し、lint を品質ゲートとして機能させる。

あわせて、唯一残っていた error 1 件（`react-hooks/immutability`）を `warn` に落とす。これにより現時点の指摘は **error 0 件 / warning 12 件** となり、blocking 化しても CI は緑を維持する。

## 背景

`.github/workflows/ci.yml` の lint ステップは `continue-on-error: true` が指定されており、**lint が失敗しても CI が success として記録される**状態だった。

この設定の問題は「既存の指摘が放置されること」ではなく、**新しく混入する error に誰も気づけないこと**にある。実際、ESLint が ESLint 10 との非互換でクラッシュしていた期間（PR #232 以前）、CI 上ではその失敗が success として記録され続けていた。

## 変更内容

### 1. `.github/workflows/ci.yml`

```diff
-      - name: Lint (advisory, non-blocking)
+      - name: Lint
         run: pnpm lint
-        continue-on-error: true
```

ステップ名も実態に合わせて変更した。`advisory, non-blocking` のままでは CI ログを読んだ人が「失敗しても問題ない」と誤解するため。

### 2. `eslint.config.mjs`

`react-hooks/immutability` を `warn` に設定した。

```js
"react-hooks/immutability": "warn",
```

**この指摘は誤検知ではない。** 既存の `react-hooks/set-state-in-effect` は「React Compiler の新ルールで誤検知が多い」という理由で `warn` にされているが、本件は理由が異なるため、コメントでその差を明記した。

該当箇所は `src/contexts/HeroContext.tsx:321`:

```
Cannot access variable before it is declared
`getZennArticlesCount` is accessed before it is declared, which prevents the
earlier access from updating when this value changes over time.
```

再帰的なリトライ処理で関数が宣言前の自身を参照している。修正には再帰構造そのものの組み替え（`useRef` の導入等）が必要で、アプリ全体の状態を持つ Context への変更となる。**認識した上で先送りする**という判断であり、その旨と「修正後は error に戻すこと」を設定ファイル内のコメントに記載した。

## Test Plan

- [x] **`pnpm lint` の exit code — 0**（CI が緑になることの直接確認）
- [x] lint の内訳 — **error 0 件 / warning 12 件**
- [x] `ci.yml` の YAML パース — 成功。`name='Lint'` / `continue-on-error` なしを確認
- [x] `pnpm exec tsc --noEmit` — **exit 0**
- [x] `pnpm format:check` — **All matched files use Prettier code style!**
- [x] `pnpm test:run` — 実行完了

### 残存する warning 12 件

| 件数 | ルール | 設定理由 |
|---|---|---|
| 10 | `react-hooks/set-state-in-effect` | 既存設定（React Compiler の誤検知） |
| 1 | `@typescript-eslint/no-unused-vars` | 既存設定（`_` プレフィックス許容） |
| 1 | `react-hooks/immutability` | 本 PR で追加（実際の指摘・先送り） |

warning が増えても CI は止まらない。止まるのは **error が新規に混入したとき**のみ。

## Breaking Changes

CI の挙動が変わる。**今後 lint に error が 1 件でも入れば CI が失敗する。**

これは意図した変更である。既存コードは error 0 件であることを確認済みのため、本 PR のマージ時点で既存の PR やブランチが即座に壊れることはない。

## 経緯（関連 PR）

| PR | 内容 | lint の状態 |
|---|---|---|
| #232 | ESLint を 9.39.5 に戻して復旧 | クラッシュ → error 34 / warning 11 |
| #237 | `try/catch` 内の JSX 構築を解消 | error 1 / warning 11 |
| 本 PR | `immutability` を warn 化 + blocking 化 | **error 0 / warning 12** |
