### PR TITLE
chore(ci): GitHub Actions を v5 に更新して Node 20 依存を解消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -44,13 +44,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
## Summary

CI で使用している GitHub Actions を v4 から v5 に更新し、Node.js 20 への依存を解消する。

## 背景

CI の実行ログに以下の警告が出力されていた。

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4,
pnpm/action-setup@v4
```

GitHub Actions のランタイムから Node.js 20 が廃止されるため、`node20` を指定している action は現在 GitHub 側が Node.js 24 で強制実行することで救済されている。この救済措置が終了すると CI が動作しなくなる。

これはアプリケーション側の Node バージョンとは無関係であり、**action 自身が動作するランタイム**の問題である。

## 各 action のランタイム宣言（実測）

各リポジトリの `action.yml` から `using:` の値を直接取得して確認した。

| action | v4 | v5 |
|---|---|---|
| `actions/checkout` | `node20` | **`node24`** |
| `actions/setup-node` | `node20` | **`node24`** |
| `pnpm/action-setup` | `node20` | **`node24`** |

3 つとも v5 で `node24` に移行しており、v5 への更新で警告の原因が解消される。

## 変更内容

`.github/workflows/ci.yml` の 6 箇所（2 ジョブ × 3 action）:

```diff
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
```

**`node-version: 22` は変更していない。** これは CI 上でアプリのビルド・テストを実行する Node のバージョンであり、本 PR の対象である「action 自身のランタイム」とは別の設定である。

## 最新版ではなく v5 を選んだ理由

実測時点での各 action の最新リリースは以下だった。

| action | 最新 | 本 PR で採用 |
|---|---|---|
| `actions/checkout` | v7.0.1 | **v5** |
| `actions/setup-node` | v7.0.0 | **v5** |
| `pnpm/action-setup` | v6.0.10 | **v5** |

本 PR の目的は「Node 20 依存の解消」であり、それは v5 で完全に達成される（上記の実測表）。

最新版まで上げる場合、v5 から最新までの間の破壊的変更を確認する必要があるが、それは「Node 20 対応」とは別の目的となる。1 つの PR に 2 つの目的を混ぜると、問題が起きた際の切り分けが困難になるため、本 PR では v5 に留める。

最新版への追従は、変更内容を確認した上で別 PR で扱うのが妥当と考える。

## Test Plan

- [x] `git diff` — **6 insertions / 6 deletions**（`@v4` → `@v5` のみ）
- [x] YAML パース検証（Python の `yaml` モジュール）— **成功**
- [x] ジョブ構成が `quality` / `test` の 2 つで変化なし
- [x] 6 箇所すべてが `@v5` になっていることを確認
- [x] `node-version: 22` が変更されていないことを確認
- [ ] **CI 実行時に Node 20 の deprecation 警告が消えること**（本 PR の CI で検証）

## Breaking Changes

なし。CI の実行環境のみの変更で、アプリケーションのコード・依存関係・ビルド成果物には影響しない。
