### PR TITLE
docs(claude): components 構成に providers/ を追加

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,7 +11,7 @@ Next.js 16 (App Router) / React 19 / TypeScript (strict) / Tailwind + CSS Module
 
 ```
 src/app/          -- App Router、ページ、API Routes
-src/components/   -- 共有UI (auth/, common/, elements/, layout/, ui/)
+src/components/   -- 共有UI (auth/, common/, elements/, layout/, providers/, ui/)
 src/features/     -- 機能モジュール（domain別 components/hooks/types/utils）
 src/lib/          -- ライブラリ/ユーティリティ
 src/contexts/     -- React Context (AudioContext, HeroContext)


### PR DESCRIPTION
## Summary

`.claude/CLAUDE.md` のディレクトリ構成に `src/components/providers/` が記載されていなかったため追加する。

変更は 1 行のみ。

```diff
-src/components/   -- 共有UI (auth/, common/, elements/, layout/, ui/)
+src/components/   -- 共有UI (auth/, common/, elements/, layout/, providers/, ui/)
```

Closes #180

## issue #180 の現状確認

issue #180（2026-01-30 作成）は 3 つの要求を含んでいたが、**実際に未対応だったのは 1 件のみ**だった。

| # | issue の要求 | 現状 | 対応 |
|---|---|---|---|
| 1 | 技術スタック表のバージョン更新（7 項目） | **表そのものが廃止済み** | 対応不要 |
| 2 | `providers/` を構成に追加 | **未対応だった** | **本 PR で対応** |
| 3 | コミットタイプに `style` を追加 | **43 行目に既に存在** | 対応済み |

### 要求 1 が対応不要な理由

issue は以下のようなバージョン表の更新を要求していた。

```
| Next.js | 16.0.0 | → | 16.1.1 |
| React   | 19.2.0 | → | 19.2.3 |
```

しかし現在の `CLAUDE.md` にこの表は存在せず、`## Stack` はメジャーバージョンのみの 1 行に集約されている。

```
Next.js 16 (App Router) / React 19 / TypeScript (strict) / Tailwind + CSS Modules / ...
```

パッチバージョンを記載しない方針に変わったため、**乖離が発生しうる記述自体が存在しない**。issue 作成後にドキュメントがリファクタされ、要求の前提が失われた形となる。

## 検証

`/authoring-claude-md` skill（Review & Optimize Mode）で評価した。

### 5 原則スコア

| # | 原則 | 評価 | 所見 |
|---|---|---|---|
| 1 | ステートレス前提のオンボーディング | OK | 目的 + スコープ外の明示 + 構造マップ + 検証コマンドが揃う |
| 2 | WHAT / WHY / HOW | OK | Rules 全 6 件に理由が付記されている |
| 3 | Less is More | OK | **48 行**（理想の 60 行未満を達成） |
| 4 | 段階的開示 | OK | `.docs/index.md` と `.claude/rules/` へのポインタあり |
| 5 | エージェント ≠ リンター | OK | 命名規則・整形ルールの記述なし |

**総合スコア: 5.0 / 5.0**

スコアが short-circuit 条件（4.5 以上）を満たしたため、skill の規定に従い改善提案フェーズ（Step 2-3）は skip した。本 PR は事実誤りの修正のみを扱う。

### 機械検証（`scripts/validate-claude-md.sh`）

```
✅ PASS [lines]: 48 lines (理想: 60行未満)
✅ PASS [docs_pointer]: .docs/ 参照あり
✅ PASS [forbidden_lint_config]: 設定値の混入なし
✅ PASS [forbidden_todo]: TODO メモ混入なし
✅ PASS [verification_cmd]: 検証コマンド検出
✅ PASS [reason_for_prohibition]: 禁止事項 + 理由記述あり
⚠️  WARN [anti_anchor]: 非主流ライブラリ検出 (vitest/pnpm)

Summary: 6 PASS / 1 WARN / 0 FAIL
```

WARN は修正前から出ているもので本変更とは無関係。skill の規定でも anti-anchor 注記は「非主流かつアンカー誤爆の実害があるカテゴリのみ」に限定されているため、対応は見送る。

### 実ディレクトリとの照合

```
実際 (ls src/components/):  auth common elements layout providers ui
修正後の CLAUDE.md:         auth/, common/, elements/, layout/, providers/, ui/
```

完全一致を確認。

## Test Plan

- [x] `git diff` — **1 insertion / 1 deletion**（14 行目のみ）
- [x] 行数が 48 行のまま変化なし
- [x] `validate-claude-md.sh` — **6 PASS / 0 FAIL**
- [x] `ls src/components/` の実測結果と記載が完全一致

## Breaking Changes

なし。ドキュメントのみの変更。
