### PR TITLE
chore(deps-dev): prettier を 3.9.6 に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
 		"eslint-plugin-prettier": "5.5.6",
 		"happy-dom": "20.11.1",
 		"postcss": "8.5.25",
-		"prettier": "3.8.3",
+		"prettier": "3.9.6",
 		"prisma": "7.9.1",
 		"tailwindcss": "4.3.3",
 		"typescript": "6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,7 +135,7 @@ importers:
         version: 10.1.8(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))(prettier@3.8.3)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))(prettier@3.9.6)
       happy-dom:
         specifier: 20.11.1
         version: 20.11.1
@@ -143,8 +143,8 @@ importers:
         specifier: 8.5.25
         version: 8.5.25
       prettier:
-        specifier: 3.8.3
-        version: 3.8.3
+        specifier: 3.9.6
+        version: 3.9.6
       prisma:
         specifier: 7.9.1
         version: 7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
@@ -2913,8 +2913,8 @@ packages:
     resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -5327,10 +5327,10 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))(prettier@3.8.3):
+  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))(prettier@3.9.6):
     dependencies:
       eslint: 9.39.5(jiti@2.7.0)
-      prettier: 3.8.3
+      prettier: 3.9.6
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.13
     optionalDependencies:
@@ -6516,7 +6516,7 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier@3.8.3: {}
+  prettier@3.9.6: {}
 
   prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3):
     dependencies:


### PR DESCRIPTION
## Summary

`prettier` を 3.8.3 → 3.9.6 に更新する。マイナーバージョン更新のみ。

## 背景

Dependabot の PR #240（dev-tooling group）には以下の 3 件が含まれていた。

| パッケージ | 変更 | 種別 |
|---|---|---|
| `@types/node` | 25 → 26 | **メジャー** |
| `typescript` | 6.0.3 → 7.0.2 | **メジャー** |
| `prettier` | 3.8.3 → 3.9.6 | マイナー |

しかし #240 の CI は **Lint & Format と Vercel の両方が fail** している（Test のみ pass）。メジャー更新 2 件が同時に含まれるため、どちらが原因かの切り分けができない。

本 PR では、**確実に適用できる `prettier` のマイナー更新のみを切り出す**。メジャー更新 2 件は移行作業として別途扱う。

## Test Plan

CI と同一のコマンドで検証した。

- [x] `pnpm lint` — **exit code 0**
- [x] `pnpm format:check` — **OK（整形差分なし）**
- [x] `pnpm exec tsc --noEmit` — **exit code 0**
- [x] `pnpm test:run` — **52 passed (7 files)**

`format:check` が通ったことにより、prettier 3.9.6 で整形ルールに変更がなく、既存コードに差分が生じないことを確認した。

## Breaking Changes

なし。`prettier` は devDependency であり、ビルド成果物には影響しない。整形結果にも変化がないことを `format:check` で確認済み。

## 残る 2 件について

`@types/node` 26 と `typescript` 7.0.2 は本 PR に含めない。

TypeScript 6 → 7 はメジャーバージョン更新であり、#240 の CI では Lint & Format が fail している。`eslint-config-next` が TypeScript の型情報を用いて lint を行うため、TypeScript のメジャー更新は lint の挙動に影響する。

これは「依存を上げる」作業ではなく「破壊的変更に対応する」移行作業であるため、別 issue として起票する。
