### PR TITLE
chore(deps-dev): @types/node を 26 に更新し typescript の major 更新を無視する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,22 @@ updates:
       day: "monday"
     open-pull-requests-limit: 10
     versioning-strategy: "increase"
-    # eslint の major 更新のみ無視する(minor/patch は従来どおり受け取る)。
-    # 理由: eslint-config-next が引き込む eslint-plugin-react が ESLint 10 に未対応で、
-    # 10.x へ上げると `pnpm lint` が TypeError でクラッシュする (PR #232 で 9.39.5 へ戻した)。
-    # eslint-plugin-react の ESLint 10 対応版 (7.8.0) が安定リリースされたら本設定を見直す。
+    # 以下 2 件は major 更新のみ無視する(minor/patch は従来どおり受け取る)。
+    # どちらも上流が未対応であることが原因で、本リポジトリ側の修正では解決しない。
+    #
+    # eslint: eslint-config-next が引き込む eslint-plugin-react が ESLint 10 に未対応で、
+    #   10.x へ上げると `pnpm lint` が TypeError でクラッシュする (PR #232 で 9.39.5 へ戻した)。
+    #   eslint-plugin-react の ESLint 10 対応版 (7.8.0) が安定リリースされたら見直す。
+    #
+    # typescript: eslint-config-next/typescript が引き込む @typescript-eslint が
+    #   TypeScript 7 に未対応。peerDependencies が `>=4.8.4 <6.1.0` で、latest (8.66.0) でも
+    #   同じ範囲のまま 9.x は未リリース。7.0.2 へ上げると typescript-estree の初期化時に
+    #   `TypeError: Cannot read properties of undefined (reading 'Cjs')` でクラッシュする。
+    #   @typescript-eslint が TypeScript 7 に対応したら見直す (issue #244)。
     ignore:
       - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
     groups:
       next:

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"@prisma/config": "7.9.1",
 		"@tailwindcss/postcss": "4.3.3",
 		"@types/howler": "2.2.13",
-		"@types/node": "25",
+		"@types/node": "26",
 		"@types/pg": "8.20.3",
 		"@types/react": "19.2.18",
 		"@types/react-dom": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ importers:
         specifier: 2.2.13
         version: 2.2.13
       '@types/node':
-        specifier: '25'
-        version: 25.9.1
+        specifier: '26'
+        version: 26.1.2
       '@types/pg':
         specifier: 8.20.3
         version: 8.20.3
@@ -158,7 +158,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(happy-dom@20.11.1)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.0.16(@types/node@26.1.2)(jiti@2.7.0))
 
 packages:
 
@@ -1090,8 +1090,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@25.9.1':
-    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+  '@types/node@26.1.2':
+    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
   '@types/pg@8.20.3':
     resolution: {integrity: sha512-4Tvg+HO6+oQaAkpT8GTYoSExzpGGZz532GXgbbCElWJQeQdMozBWxEKNBhJJpHFjWXsMxqPbyypvj/89FWNoSQ==}
@@ -3338,8 +3338,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
@@ -4433,13 +4433,13 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@25.9.1':
+  '@types/node@26.1.2':
     dependencies:
-      undici-types: 7.24.6
+      undici-types: 8.3.0
 
   '@types/pg@8.20.3':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 26.1.2
       pg-protocol: 1.14.0
       pg-types: 2.2.0
 
@@ -4459,7 +4459,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 26.1.2
 
   '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -4712,13 +4712,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))':
+  '@vitest/mocker@4.1.10(vite@8.0.16(@types/node@26.1.2)(jiti@2.7.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@26.1.2)(jiti@2.7.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -4895,7 +4895,7 @@ snapshots:
 
   buffer-image-size@0.6.4:
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 26.1.2
 
   c12@3.3.4:
     dependencies:
@@ -5640,7 +5640,7 @@ snapshots:
 
   happy-dom@20.11.1:
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 26.1.2
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       buffer-image-size: 0.6.4
@@ -7058,7 +7058,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@7.24.6: {}
+  undici-types@8.3.0: {}
 
   undici@7.29.0: {}
 
@@ -7152,7 +7152,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0):
+  vite@8.0.16(@types/node@26.1.2)(jiti@2.7.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -7160,14 +7160,14 @@ snapshots:
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 25.9.1
+      '@types/node': 26.1.2
       fsevents: 2.3.3
       jiti: 2.7.0
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(happy-dom@20.11.1)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.0.16(@types/node@26.1.2)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
+      '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@26.1.2)(jiti@2.7.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -7184,11 +7184,11 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@26.1.2)(jiti@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      '@types/node': 25.9.1
+      '@types/node': 26.1.2
       happy-dom: 20.11.1
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## Summary

Dependabot PR #246（dev-tooling group）を分解し、**適用できる `@types/node` 26 のみを取り込む**。同梱されていた `typescript` 7.0.2 は上流ブロッカーと判明したため、Dependabot の ignore に追加して提案自体を止める。

## 背景

#246 には 2 件のメジャー更新が同梱されていた。

| パッケージ | 変更 | CI |
|---|---|---|
| `@types/node` | 25 → 26 | — |
| `typescript` | 6.0.3 → 7.0.2 | — |

PR 全体としては **Lint & Format と Vercel の両方が fail**（Test のみ pass）していたが、2 件同梱のためどちらが原因か切り分けられていなかった。

## 切り分けの結果

### `typescript` 7 は上流ブロッカー

CI ログ（run `31052722019`）の失敗箇所:

```
Oops! Something went wrong! :(

ESLint: 9.39.5

TypeError: Cannot read properties of undefined (reading 'Cjs')
    at Object.<anonymous> (.../@typescript-eslint+typescript-estree@8.60.1_typescript@7.0.2/
                            .../typescript-estree/dist/create-program/shared.js:59:18)
 ELIFECYCLE  Command failed with exit code 2.
```

ESLint 本体ではなく `@typescript-eslint/typescript-estree` の**初期化時**にクラッシュしている。ルール違反の指摘が出る手前で死ぬため、「どのルールが落ちているか」という問い自体が成立しない。

npm 実測:

| 項目 | 値 |
|---|---|
| `@typescript-eslint/typescript-estree` の `peerDependencies.typescript` | **`>=4.8.4 <6.1.0`** |
| latest バージョン | 8.66.0 |
| latest の peer range | **同じ** |
| 9.x の存在 | **なし**（メジャーは 0〜8 のみ） |

**リリース済みのどのバージョンも TypeScript 7 をサポートしていない。** `eslint.config.mjs:3` で `eslint-config-next/typescript` を読み込み、`eslint.config.mjs:23` で `@typescript-eslint/no-unused-vars` を直接設定しているため、typescript-eslint を外す選択肢も取れない。

`eslint-plugin-react` が ESLint 10 に未対応で #232 が 9.39.5 へ戻したのと同じ構造であり、**本リポジトリ側のコード修正では解決しない**。

### `@types/node` 26 は単独で全通過

| 検証 | 結果 |
|---|---|
| `pnpm lint` | **exit 0**（error 0 / warning 12） |
| `pnpm format:check` | **exit 0** |
| `pnpm exec tsc --noEmit` | **exit 0** |
| `pnpm test:run` | **52 passed (7 files)** |
| `pnpm build` | **exit 0**（全ルート生成） |
| `pnpm install --frozen-lockfile` | **exit 0** |

これにより **#246 の失敗は `typescript` 7 に起因すると確定**した。

## 変更内容

### 1. `chore(ci)`: `typescript` の major を Dependabot で無視

`eslint` と同じ扱いにする。minor/patch は従来どおり受け取る。

```yaml
ignore:
  - dependency-name: "eslint"
    update-types: ["version-update:semver-major"]
  - dependency-name: "typescript"
    update-types: ["version-update:semver-major"]
```

理由はコメントとして併記した。`@typescript-eslint` が TypeScript 7 に対応したら見直す。

### 2. `chore(deps-dev)`: `@types/node` 25 → 26

lockfile の差分は `@types/node` と依存の `undici-types`（7.24.6 → 8.3.0）、および `vitest` / `vite` / `@vitest/mocker` の peer ハッシュのみ。無関係なパッケージのドリフトは含まない。

## Test Plan

CI と同一のコマンドで検証済み（上表のとおり）。`pnpm build` まで通しているため、Vercel 側も通過する見込み。

## Breaking Changes

なし。`@types/node` は devDependency であり、型定義のみでビルド成果物には含まれない。

## 残る課題

`typescript` 6 → 7 の移行は **issue #244** で追跡する。上流（`@typescript-eslint`）の対応待ちであり、こちらから着手できる作業は現時点で存在しない。

本 PR のマージにより Dependabot が #246 を自動的にクローズするか、`typescript` を除いた形で再生成する。
