### PR TITLE
chore(deps): Clerk v7 へ移行し @clerk/types への依存を解消する

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
 	"dependencies": {
 		"@ai-sdk/google": "4.0.31",
 		"@ai-sdk/react": "4.0.51",
-		"@clerk/nextjs": "6.39.3",
-		"@clerk/types": "4.101.25",
+		"@clerk/nextjs": "7.6.4",
 		"@google/generative-ai": "0.24.1",
 		"@phosphor-icons/react": "2.1.10",
 		"@prisma/adapter-pg": "7.9.1",
@@ -51,7 +50,7 @@
 		"react-icons": "5.7.0",
 		"react-markdown": "10.1.0",
 		"server-only": "0.0.1",
-		"svix": "1.84.1",
+		"svix": "1.99.1",
 		"tailwind-merge": "3.6.0",
 		"tailwindcss-animate": "1.0.7",
 		"zod": "4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,11 +24,8 @@ importers:
         specifier: 4.0.51
         version: 4.0.51(react@19.2.8)(zod@4.4.3)
       '@clerk/nextjs':
-        specifier: 6.39.3
-        version: 6.39.3(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@clerk/types':
-        specifier: 4.101.25
-        version: 4.101.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 7.6.4
+        version: 7.6.4(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@google/generative-ai':
         specifier: 0.24.1
         version: 0.24.1
@@ -87,8 +84,8 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
       svix:
-        specifier: 1.84.1
-        version: 1.84.1
+        specifier: 1.99.1
+        version: 1.99.1
       tailwind-merge:
         specifier: 3.6.0
         version: 3.6.0
@@ -279,28 +276,28 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
-  '@clerk/backend@2.33.5':
-    resolution: {integrity: sha512-YOzUYJfb1d4w+0rKKm+LnnNpkJGQ+NI/g7qmF3mgaSN9X9huteuwCZyufdsI7z2DDkwy/yGRgb9eUWV96t7xLg==}
-    engines: {node: '>=18.17.0'}
+  '@clerk/backend@3.15.1':
+    resolution: {integrity: sha512-/haECiKneGkRXkedhNHYp8tK9kjDpWIf6vtWhd+zeJ+HE6a7A9UOcajLUipvbqe834iAJAewhzUretCSrhAglg==}
+    engines: {node: '>=20.9.0'}
 
-  '@clerk/clerk-react@5.61.8':
-    resolution: {integrity: sha512-n+k3q3xeyDkIPGTVA1J4Pd0+6MbS9Ia04qNlecOztTHwFfcirO5hy4TpOXrpGnO+GzYBuUMp7pYc3//ybMdEfg==}
-    engines: {node: '>=18.17.0'}
+  '@clerk/nextjs@7.6.4':
+    resolution: {integrity: sha512-eDo55Yheel2xoYSvVRsg8SKiZV5sB57NIfX2tTuSRCHh2/pG20nZ2wUHg7CdVQ7xtwtIp9qkmGScSkjm/T4++Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      next: ^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+
+  '@clerk/react@6.12.11':
+    resolution: {integrity: sha512-qetJGDcQMHg7GY9H1VK1znSyMEoxe//dgP+qCWjD81wMm9EiDy0ShYP9aNu9fe2CxEe/7eX8Ax+iemZA5GuexQ==}
+    engines: {node: '>=20.9.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
 
-  '@clerk/nextjs@6.39.3':
-    resolution: {integrity: sha512-a64lJ1IlV1uA7eEe8DOx+v2bkNOhnTsNlB5THP/xkHvynHqZhc74Yt05sm1vTniWwhJpJspAZ95pCWUX/RVZ2Q==}
-    engines: {node: '>=18.17.0'}
-    peerDependencies:
-      next: ^13.5.7 || ^14.2.25 || ^15.2.3 || ^16
-      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
-      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
-
-  '@clerk/shared@3.47.7':
-    resolution: {integrity: sha512-9Yv4MJFEaC7BzV0whxa4txQ4SoMu/3j1LBnI85EBykb5CcfXxIKvNX/9sjMUUySHlTOjsj7XZa5i3W5Dx02K/Q==}
-    engines: {node: '>=18.17.0'}
+  '@clerk/shared@4.26.0':
+    resolution: {integrity: sha512-CYPOxpvKuKidy4ReSf3XU3YF28kr3QlmdJuFtwlrChK/GnLJxKp54GmUYtgoh1p61IHqirWfc8MerxlUhwWLFQ==}
+    engines: {node: '>=20.9.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -309,10 +306,6 @@ packages:
         optional: true
       react-dom:
         optional: true
-
-  '@clerk/types@4.101.25':
-    resolution: {integrity: sha512-gPxm3hlBkP7B9EfKyp3/UDonNOjg7Z0UvqfrMj5u8gA8nyzvC1UFYtSTTmTfgSY82+5Yo38YV0DYu9vNf6t9CQ==}
-    engines: {node: '>=18.17.0'}
 
   '@electric-sql/pglite-socket@0.1.3':
     resolution: {integrity: sha512-LAciWM0M1dCL8hlsxu2venbVZcdxema0BtDfpWYVqr+Y468UADw0pFWidhKw1M8sfJ8rdLT71tjMmnirf/IZRQ==}
@@ -1012,6 +1005,9 @@ packages:
   '@tailwindcss/postcss@4.3.3':
     resolution: {integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==}
 
+  '@tanstack/query-core@5.101.4':
+    resolution: {integrity: sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -1574,9 +1570,6 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
-
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -3229,13 +3222,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svix@1.84.1:
-    resolution: {integrity: sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==}
-
-  swr@2.3.4:
-    resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
-    peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  svix@1.99.1:
+    resolution: {integrity: sha512-JfpvbAg5iT5NagDAfOq3e6Ci6NbOMbMm6C3DnfDBB60m2JDK+Z2hXPE9XNAmutb53DCdPoih1V70IbklZnX09A==}
 
   swr@2.5.0:
     resolution: {integrity: sha512-W0GomadRJe9OfzIoRX0kZHhDSaRRfdiOUeH6uazgR05SibBhDNwfdTbhAxmFtObvkf59fFymo22mooKukosvNA==}
@@ -3379,10 +3367,6 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  uuid@11.1.1:
-    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
-    hasBin: true
 
   valibot@1.4.2:
     resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
@@ -3712,53 +3696,42 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@clerk/backend@2.33.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@clerk/backend@3.15.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@clerk/shared': 3.47.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@clerk/types': 4.101.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@clerk/shared': 4.26.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       standardwebhooks: 1.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@clerk/clerk-react@5.61.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@clerk/nextjs@7.6.4(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@clerk/shared': 3.47.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      tslib: 2.8.1
-
-  '@clerk/nextjs@6.39.3(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@clerk/backend': 2.33.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@clerk/clerk-react': 5.61.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@clerk/shared': 3.47.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@clerk/types': 4.101.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@clerk/backend': 3.15.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@clerk/react': 6.12.11(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@clerk/shared': 4.26.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       server-only: 0.0.1
       tslib: 2.8.1
 
-  '@clerk/shared@3.47.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@clerk/react@6.12.11(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      csstype: 3.1.3
+      '@clerk/shared': 4.26.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      tslib: 2.8.1
+
+  '@clerk/shared@4.26.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/query-core': 5.101.4
       dequal: 2.0.3
       glob-to-regexp: 0.4.1
       js-cookie: 3.0.7
-      std-env: 3.10.0
-      swr: 2.3.4(react@19.2.8)
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-
-  '@clerk/types@4.101.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@clerk/shared': 3.47.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-    transitivePeerDependencies:
-      - react
-      - react-dom
 
   '@electric-sql/pglite-socket@0.1.3(@electric-sql/pglite@0.4.3)':
     dependencies:
@@ -4355,6 +4328,8 @@ snapshots:
       '@tailwindcss/oxide': 4.3.3
       postcss: 8.5.25
       tailwindcss: 4.3.3
+
+  '@tanstack/query-core@5.101.4': {}
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -4983,8 +4958,6 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  csstype@3.1.3: {}
 
   csstype@3.2.3: {}
 
@@ -6936,16 +6909,9 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svix@1.84.1:
+  svix@1.99.1:
     dependencies:
       standardwebhooks: 1.0.0
-      uuid: 11.1.1
-
-  swr@2.3.4(react@19.2.8):
-    dependencies:
-      dequal: 2.0.3
-      react: 19.2.8
-      use-sync-external-store: 1.6.0(react@19.2.8)
 
   swr@2.5.0(react@19.2.8):
     dependencies:
@@ -7135,8 +7101,6 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.8):
     dependencies:
       react: 19.2.8
-
-  uuid@11.1.1: {}
 
   valibot@1.4.2(typescript@6.0.3):
     optionalDependencies:

--- a/src/features/connection/components/connection-user-profile-header/ConnectionUserProfileHeader.tsx
+++ b/src/features/connection/components/connection-user-profile-header/ConnectionUserProfileHeader.tsx
@@ -1,4 +1,4 @@
-import { UserResource } from "@clerk/types";
+import type { UserResource } from "@clerk/nextjs/types";
 import styles from "./ConnectionUserProfileHeader.module.css";
 import UserIconButton from "@/components/auth/user-icon-button/UserIconButton";
 

--- a/src/features/connection/hooks/useSessionManagement.ts
+++ b/src/features/connection/hooks/useSessionManagement.ts
@@ -3,7 +3,7 @@
 import "client-only";
 
 import { useEffect, Dispatch, SetStateAction } from "react";
-import { UserResource } from "@clerk/types";
+import type { UserResource } from "@clerk/nextjs/types";
 import { SESSION_ID_KEY, LOGOUT_FLAG_KEY } from "@/features/connection/constants";
 import { storage } from "@/utils/storage";
 


### PR DESCRIPTION
## Summary

`@clerk/nextjs` を 6.39.3 → 7.6.4（メジャー更新）へ移行する。Dependabot PR #219 がそのままでは Vercel ビルドに失敗していた問題を解消し、issue #245 をクローズする。

Closes #245

## 背景

#219（clerk-auth group）の CI 結果は以下だった。

| チェック | 結果 |
|---|---|
| Lint & Format | pass |
| Test | pass |
| **Vercel** | **fail** |

同時期の他の Dependabot PR（#212 ai-sdk / #216 styling / #234 vitest / #236 happy-dom）は Vercel が success だったため、環境要因ではなく本 PR の内容が原因と切り分け済みだった。ただし **Vercel のビルドログは GitHub API から読めない**ため、ローカルで再現させて原因を特定した。

Lint と Test が通るのに Vercel だけ落ちる理由は明確で、**`next build` の型チェック段階で初めて露出する**エラーだったため。テスト（52 件）は Clerk のコードを実行しておらず、lint は静的解析でビルドエラーを検出しない。

## 原因: `@clerk/shared` の二重インストール

ローカルで再現したビルドエラー:

```
Failed to type check.

./src/features/connection/components/connection-page-client/ConnectionPageClient.tsx:61:3
Type error: Type '@clerk/shared@4.26.0 ... UserResource | null | undefined'
  is not assignable to type '@clerk/shared@3.47.8 ... UserResource | null | undefined'.
  Property 'samlAccounts' is missing in type '@clerk/shared@4.26.0 ... UserResource'
  but required in type '@clerk/shared@3.47.8 ... UserResource'.
```

依存グラフの実測:

```
@clerk/nextjs 7.6.4
├── @clerk/backend 3.15.1 → @clerk/shared 4.26.0
├── @clerk/react 6.12.11  → @clerk/shared 4.26.0
└──                         @clerk/shared 4.26.0

@clerk/types 4.101.26     → @clerk/shared 3.47.8   ← 古い
```

`@clerk/nextjs@7.6.4` の `dependencies` は `@clerk/react` / `@clerk/shared` / `@clerk/backend` / `tslib` / `server-only` のみで、**`@clerk/types` に依存していない**。

本プロジェクトのソース 2 箇所が `@clerk/types` から `UserResource` を import していたため、そちらが引き込む古い `@clerk/shared@3.47.8` の型を掴んでいた。`useUser()` が返すのは新しい 4.26.0 の型なので、`useSessionManagement` への引き渡しで不一致になる。

## 対応

Clerk 公式の core-3 アップグレードガイドに以下の記載がある。

> The `@clerk/types` package is **deprecated**. Developers should transition to importing types from the public `/types` entry point of their specific Clerk SDK for framework-specific code, or from `@clerk/shared/types` for framework-agnostic code.
>
> ```ts
> import type { UserResource } from '@clerk/nextjs/types'
> ```

出典: `clerk/clerk-docs` の `docs/guides/development/upgrading/upgrade-guides/core-3.mdx`

インストール済みの `@clerk/nextjs@7.6.4` の型定義ファイルを直接確認したところ、ガイドと一致していた。

```ts
// node_modules/@clerk/nextjs/dist/types/types/index.d.ts
/**
 * Re-exports all types from @clerk/shared/types along with Next.js-specific types.
 * This allows consumers to import types from @clerk/nextjs/types instead of
 * installing @clerk/types separately.
 */
export type * from '@clerk/shared/types';
```

### 変更内容

| ファイル | 変更 |
|---|---|
| `package.json` | `@clerk/nextjs` 6.39.3 → 7.6.4 / `svix` 1.84.1 → 1.99.1 / **`@clerk/types` を削除** |
| `ConnectionUserProfileHeader.tsx:1` | `@clerk/types` → `@clerk/nextjs/types`（type-only import） |
| `useSessionManagement.ts:6` | 同上 |

これにより `@clerk/shared` は **4.26.0 に一本化**された。

## Test Plan

CI と同一のコマンドで検証した。

- [x] `pnpm build` — **exit 0**（全ルート生成）
- [x] `pnpm lint` — **exit 0**（error 0 / warning 12）
- [x] `pnpm format:check` — **exit 0**
- [x] `pnpm exec tsc --noEmit` — **exit 0**
- [x] `pnpm test:run` — **52 passed (7 files)**
- [x] `pnpm install --frozen-lockfile` — **exit 0**

ビルドログに `connection() rejects when the prerender is complete` が 132 行出力されるが、**Clerk v6 のビルドでも同数（132 行）**であり、本変更とは無関係の既存挙動。

## 破壊的変更の判定

issue #245 に挙げた 3 件について、コードを実測して判定した。

| 公式が示す変更点 | 本プロジェクトの状態 | 判定 |
|---|---|---|
| `ClerkProvider` を `<html>` ではなく `<body>` の内側へ | `src/app/layout.tsx:56` が `<body>`、`:57` が `ClerkProviderWrapper` | **既に内側。対応不要** |
| `clerkMiddleware()` に `secretKey` を渡す場合 `CLERK_ENCRYPTION_KEY` が必要 | `src/proxy.ts:3` は `clerkMiddleware(() => {...})` で `secretKey` を渡していない | **該当なし** |
| `auth.protect()` が未認証時に 404 ではなく 401 を返す | `src/` に使用箇所ゼロ | **該当なし** |
| Next.js 最小バージョン 15.2.3 | 現在 16.2.11 | **条件を満たす** |

## 検証の限界（重要）

**ビルドと型チェックは通ったが、実行時の動作は検証していない。**

Clerk はログイン・セッション管理という中核機能であり、特に `useSessionManagement` はセッション切れの検出に関わる。**Preview デプロイで実際にログインを試すことを推奨する。**

確認すべき項目:

- `/connection` でのログイン・ログアウト
- セッション切れ時の挙動（`useSessionManagement` の再ログイン検出）
- `/dashboard` 等の認証必須ページへのアクセス
- Clerk Webhook（`src/app/api/webhooks/clerk/route.ts`。`svix` 1.99.1 の署名検証）

## 補足: `pnpm.overrides` の `uuid` について

`svix` 1.99.1 は `uuid` に依存しなくなったため、`pnpm.overrides` の `"uuid": "11.1.1"` は現状で何も強制しない状態になる（lockfile 内の `uuid` エントリは 0 件）。

ただし**本 PR を revert すると `svix` 1.84.1 へ戻り、`uuid` 10.0.0 が復活して override が再び必要になる**。巻き戻しの安全性を優先し、1 行の保険として残置した。

`svix` の更新が安定して定着した後に、別途整理する余地がある。
