### PR TITLE
fix(connection): Zenn連携の一意制約違反に専用メッセージを返す

### DIFF
--- a/src/features/connection/_actions/zennConnection.ts
+++ b/src/features/connection/_actions/zennConnection.ts
@@ -286,6 +286,18 @@ export async function connectZenn(
 		};
 	} catch (error) {
 		console.error("Zenn連携エラー:", error);
+
+		// ユーザー名が既に使われている場合
+		// (User.username は @unique。別アカウントが同じZennユーザー名を先に連携している)
+		// 一意制約違反は再試行しても解消しないため、汎用の「時間をおいて」メッセージに
+		// 丸めると利用者が無限に再試行することになる。
+		if (error && typeof error === "object" && "code" in error && error.code === "P2002") {
+			return {
+				success: false,
+				error: "このZennユーザー名は既に使用されています。別のユーザー名を入力してください。",
+			};
+		}
+
 		return {
 			success: false,
 			error: "予期しないエラーが発生しました。時間をおいて再度お試しください。",


### PR DESCRIPTION
## Summary

Zenn ユーザー名が既に使われている場合に、`connectZenn` が返すエラーメッセージを実態に合わせる。

Refs #248

## 背景

Zenn 連携が失敗したとき、UI にはこう表示されていた。

```
予期しないエラーが発生しました。時間をおいて再度お試しください。
```

実体は Prisma の一意制約違反（`P2002`）で、**時間をおいても解消しない**。

```
prisma:error
Invalid `prisma.user.create()` invocation
Unique constraint failed on the fields: (`username`)

  code: 'P2002'
  at connectZenn (src/features/connection/_actions/zennConnection.ts:252:20)
```

汎用の catch がすべてを同じメッセージに丸めていたため、以下 2 つの実害があった。

1. **利用者が無限に再試行する。** 「時間をおいて」は再試行で直る場合の文言だが、一意制約違反は何度やっても同じ結果になる
2. **原因の特定にサーバーログが必要だった。** issue #248 の調査で、UI からは何が起きているか一切分からなかった

## 本番でも発生する

`prisma/schema.prisma:12` の定義:

```prisma
username  String  @unique
```

`connectZenn` は `username` に Zenn ユーザー名を格納する。つまり **ユーザー A が `foo` を連携済みのとき、ユーザー B が同じ `foo` を入力すると本番でも同じエラーになる**。ローカル環境固有の問題ではない。

## 変更内容

`connectZenn` の catch に `P2002` の個別処理を追加する（+12 行）。

```ts
} catch (error) {
  console.error("Zenn連携エラー:", error);

  // ユーザー名が既に使われている場合
  // (User.username は @unique。別アカウントが同じZennユーザー名を先に連携している)
  // 一意制約違反は再試行しても解消しないため、汎用の「時間をおいて」メッセージに
  // 丸めると利用者が無限に再試行することになる。
  if (error && typeof error === "object" && "code" in error && error.code === "P2002") {
    return {
      success: false,
      error: "このZennユーザー名は既に使用されています。別のユーザー名を入力してください。",
    };
  }

  return {
    success: false,
    error: "予期しないエラーが発生しました。時間をおいて再度お試しください。",
  };
}
```

### 既存パターンへの追従

同ファイルの `syncZennArticles`（410 行目付近）と連携解除（480 行目付近）は、既に同じ形で `P2025` を個別処理している。

```ts
if (error && typeof error === "object" && "code" in error && error.code === "P2025") {
  return { success: false, error: "ユーザー情報が見つかりません。再度ログインしてください。" };
}
```

新しい規約を持ち込まず、このパターンに揃えた。

## Test Plan

`next` 16.2.12（#250 マージ後の main）の上で検証した。

- [x] `pnpm lint` — **exit 0**（error 0 / warning 12）
- [x] `pnpm format:check` — **exit 0**
- [x] `pnpm exec tsc --noEmit` — **exit 0**
- [x] `pnpm test:run` — **52 passed (7 files)**
- [x] `pnpm build` — **exit 0**
- [x] `pnpm install --frozen-lockfile` — **exit 0**

## Breaking Changes

なし。エラー時に返す文字列が変わるのみで、成功時の挙動・型・API に変更はない。

## 検証の限界

**実際に一意制約違反を発生させた状態での UI 表示は未検証。** 再現には同じ Zenn ユーザー名を持つ 2 アカウントが必要で、本番データを使わずに再現する手段が現状ない（issue #248 の開発用 DB 分離が済めば可能になる）。

分岐条件は既存の `P2025` 処理と同一の形であり、`error.code` の比較のみで副作用を持たない。

## 補足: メッセージの表現について

`P2002` が `username` / `email` / `clerkId` のどのフィールドで起きたかは、現在の構成では判別できない。Prisma 7.9.1 + `@prisma/adapter-pg` の場合、エラーの `meta` には `modelName` と `driverAdapterError` のみが入り、`meta.target` が存在しないため（実測）。

そのため以下の方針を採った。

- 圧倒的多数のケースである `username` 衝突を想定した文言にする
- ただし「別のアカウントが」と断定せず「既に使用されています」に留める（同一ユーザーの二重送信で `clerkId` が衝突する競合状態でも誤りにならない）

`meta.target` が利用可能になれば、フィールド別のメッセージへ精緻化する余地がある。
