### PR TITLE
revert(connection): P2002 の専用メッセージを撤回する

### DIFF
--- a/src/features/connection/_actions/zennConnection.ts
+++ b/src/features/connection/_actions/zennConnection.ts
@@ -286,18 +286,6 @@ export async function connectZenn(
 		};
 	} catch (error) {
 		console.error("Zenn連携エラー:", error);
-
-		// ユーザー名が既に使われている場合
-		// (User.username は @unique。別アカウントが同じZennユーザー名を先に連携している)
-		// 一意制約違反は再試行しても解消しないため、汎用の「時間をおいて」メッセージに
-		// 丸めると利用者が無限に再試行することになる。
-		if (error && typeof error === "object" && "code" in error && error.code === "P2002") {
-			return {
-				success: false,
-				error: "このZennユーザー名は既に使用されています。別のユーザー名を入力してください。",
-			};
-		}
-
 		return {
 			success: false,
 			error: "予期しないエラーが発生しました。時間をおいて再度お試しください。",


### PR DESCRIPTION
## Summary

PR #252 で追加したエラーメッセージを撤回し、#252 適用前の状態に戻す。

Reverts #252 / Refs #248

## 撤回する理由

追加したメッセージが連携ページの文脈に合っていない。

```
このZennユーザー名は既に使用されています。別のユーザー名を入力してください。
```

`/connection` は **Zenn アカウントを紐付ける画面**であり、アカウント作成画面ではない。利用者が持つ Zenn アカウントは 1 つであり、「別のユーザー名を入力する」という指示は実行できない。

元の汎用メッセージ（`予期しないエラーが発生しました。時間をおいて再度お試しください。`）も不親切ではあるが、少なくとも誤った行動を促さない。

## 実装時の誤り

`User.username` フィールドが何を表すかを確認せずに実装した。

| フィールド | 意味 | 制約 | 設定箇所 |
|---|---|---|---|
| `username` | **Clerk のユーザー名**（無ければ `user_<clerkId先頭8文字>` を自動生成） | `@unique` | `src/app/api/webhooks/clerk/route.ts:70` |
| `zennUsername` | **Zenn のアカウント名** | `String?`（**unique 制約なし**） | `connectZenn` |

`P2002`（一意制約違反）という症状だけを見て、それが「Zenn ユーザー名の重複」だと判断した。しかし制約が掛かっているのは Clerk 側の `username` 欄である。

## 未確認のままマージした事項

以下を確認せずにドメイン文言を変更したことが根本の誤り。

- `connectZenn` の create パスが本番でどの条件下で走るのか
- `username` フィールドがアプリのどこで使われているのか
- 連携完了後に UI が何をどう変えるのか
- 今回観測した `P2002` が本番の利用者にも起こり得る事象なのか

## Test Plan

- [x] `pnpm lint` — **exit 0**（error 0 / warning 12）
- [x] `pnpm format:check` — **exit 0**
- [x] `pnpm exec tsc --noEmit` — **exit 0**
- [x] `pnpm test:run` — **52 passed (7 files)**
- [x] `pnpm build` — **exit 0**
- [x] `git diff a842c61~1` — **差分ゼロ**（#252 マージ前と完全一致）

## Breaking Changes

なし。#252 が変更したのはエラー時に返す文字列のみで、本 PR はそれを元に戻す。

## 今後

`P2002` が実際にどういう条件で発生し、利用者に何を伝えるべきかは、上記「未確認のままマージした事項」を実測してから改めて判断する。issue #248 の環境分離が済めば、本番データを使わずに再現・検証できるようになる。
