### PR TITLE
fix(connection): 新規作成時の username に Clerk 由来の値を入れる

### DIFF
--- a/src/features/connection/_actions/zennConnection.ts
+++ b/src/features/connection/_actions/zennConnection.ts
@@ -249,10 +249,19 @@ export async function connectZenn(
 			user = updatedUser as UserInfo;
 		} else {
 			// 新規ユーザー作成
+			//
+			// User.username は Clerk 側のユーザー名を入れる欄であり (@unique)、
+			// Zennのユーザー名は zennUsername (制約なし) が持つ。
+			// ここで username に Zennのユーザー名を入れると、別ユーザーが同じ名前を
+			// 既に持っていた場合に一意制約違反 (P2002) になる。利用者のZennアカウントは
+			// 1つなので入力を変える余地がなく、復帰する手段がない。
+			// Clerk Webhook (api/webhooks/clerk/route.ts) と同じ規則で生成する。
+			const usernameForCreate = clerkUser.username || `user_${userId.substring(0, 8)}`;
+
 			const newUser = await prisma.user.create({
 				data: {
 					clerkId: userId,
-					username,
+					username: usernameForCreate,
 					email: emailFromClerk,
 					zennUsername: username,
 					zennArticleCount: articleCount,


### PR DESCRIPTION
## Summary

`connectZenn` の新規ユーザー作成が `User.username` に **Zenn のユーザー名**を入れていた問題を修正する。`username` は Clerk 側のユーザー名を保持する欄（`@unique`）であり、Zenn のユーザー名は `zennUsername`（制約なし）が持つ。

Refs #248

## 背景

issue #248 の調査中、ローカルで Zenn 連携が一意制約違反（`P2002`）で失敗した。当初これを「エラーメッセージが不親切な問題」と捉えて PR #252 を出したが、メッセージが連携ページの文脈に合っておらず PR #253 で revert した。

改めてコードとデータを実測した結果、**問題はメッセージではなく `username` に入れる値そのもの**だと判明した。

## フィールドの意味

| フィールド | 意味 | 制約 | 設定箇所 |
|---|---|---|---|
| `username` | **Clerk のユーザー名**（無ければ `user_<clerkId先頭8文字>`） | `@unique` | `api/webhooks/clerk/route.ts:70` |
| `zennUsername` | **Zenn のアカウント名** | `String?`（**制約なし**） | `connectZenn` |

`connectZenn` の create パス（`zennConnection.ts:255`）だけが、`username` に Zenn のユーザー名を入れていた。

## 発生条件

```
条件A: findFirst({OR:[clerkId, email]}) が空振り
       = Clerk Webhook がまだ行を作っていない
                    ↓
条件B: create する username が既存行の username と衝突
                    ↓
                  P2002
```

通常は Webhook が先に行を作るため `findFirst({clerkId})` が当たり、**update パス**を通る。update は `username` を触らないため `P2002` は起きない。条件A が成立したときだけ create パスへ落ちる。

## 衝突相手が本番 DB に実在する

本番 DB を実測したところ、**Clerk 側で削除されたアカウントに対応する行が残っていた**。

| DB `username` | DB email | Clerk Users に存在するか |
|---|---|---|
| `user_user_2y5` | `wata***il.com` | あり |
| **`bojjiartdev`** | `bojj***il.com` | **なし** |
| `user_user_32l` | `kais***il.com` | あり |
| **`camoneart`** | `camo***il.com` | **なし** |
| `dendedev` | `lden***il.com` | あり |

`username="camoneart"` の行（`updatedAt=2026-01-29`）は、対応する Clerk アカウントが削除済みにもかかわらず残存している。**同じ Zenn アカウント `camoneart` を別の Clerk アカウントから連携する際、create パスが走れば必ずこの行と衝突する。**

実際、Clerk アカウントを作り直して同じ Zenn アカウントを連携する操作が本日行われている（Webhook が先に行を作ったため update パスを通り成功した）。Webhook の配信が遅延・失敗していれば `P2002` になっていた。

## 変更内容

Clerk Webhook と同じ規則で生成する。

```ts
} else {
	// 新規ユーザー作成
	//
	// User.username は Clerk 側のユーザー名を入れる欄であり (@unique)、
	// Zennのユーザー名は zennUsername (制約なし) が持つ。
	// ここで username に Zennのユーザー名を入れると、別ユーザーが同じ名前を
	// 既に持っていた場合に一意制約違反 (P2002) になる。利用者のZennアカウントは
	// 1つなので入力を変える余地がなく、復帰する手段がない。
	// Clerk Webhook (api/webhooks/clerk/route.ts) と同じ規則で生成する。
	const usernameForCreate = clerkUser.username || `user_${userId.substring(0, 8)}`;

	const newUser = await prisma.user.create({
		data: {
			clerkId: userId,
			username: usernameForCreate,
			email: emailFromClerk,
			zennUsername: username,    // ← 従来どおり Zenn のユーザー名
			...
```

`clerkUser.username` の型は `string | null`（`@clerk/backend@3.15.1` の `api/resources/User.d.ts:44`）。`currentUser()` の戻り値から取得できることを確認済み。

## `username` が消費されていないことの確認

値を変えても表示・ロジックに影響しないことを、以下で確認した。

| 確認箇所 | 結果 |
|---|---|
| `UserInfo` 型（`features/connection/types/index.ts`） | **`username` を含まない** |
| `src/features` / `src/components` / `src/contexts` | **表示箇所なし** |
| AI 探索が渡す `@${username}` | **`zennUsername` を渡している**（`ExplorePageClient.tsx:107`） |

UI を駆動しているのは `zennUsername`（連携表示・Zenn リンク・記事取得・AI 探索・ゲスト判定）と `level`（勇者レベル・アイテム・仲間・称号）であり、どちらも本 PR では無変更。

### 書き込み経路の到達可能性

| # | 経路 | UI から到達するか |
|---|---|---|
| 1 | Webhook `route.ts:70` | **する**（Clerk サインアップ時） |
| 2 | `api/user` POST `:243` | **しない**（唯一の呼び出し口 `updateUserProfile` が `ConnectionPageClient.tsx:207` でスタブに差し替え済み） |
| 3 | `connectZenn` create `:255` | **する**（条件A 成立時） |

本 PR が変更するのは 3 のみ。

## Test Plan

- [x] `pnpm lint` — **exit 0**（error 0 / warning 12）
- [x] `pnpm format:check` — **exit 0**
- [x] `pnpm exec tsc --noEmit` — **exit 0**
- [x] `pnpm test:run` — **52 passed (7 files)**
- [x] `pnpm build` — **exit 0**

## Breaking Changes

なし。既存行の `username` は変更しない。本 PR 以降に作られる行の値だけが変わる。

## 検証の限界

**条件A が成立した状態での実行時動作は未検証。** 再現には Webhook を意図的に失敗させる必要があり、本番データを使わずに再現する手段が現状ない（issue #248 の環境分離が済めば可能になる）。

分岐は既存の Webhook と同一の式であり、`clerkUser.username` が `null` の場合のフォールバックも同一。

## 本 PR の対象外（別途 issue を起票する）

本調査で以下の 2 点が判明したが、本 PR のスコープ外とする。

1. **孤児行の残存** — Clerk 側で削除されたアカウントの DB 行が 2 件残っている。逆に Clerk に存在するユーザーで DB 行が無いものも 1 件ある
2. **`user.deleted` の失敗が観測できない** — ハンドラ（`route.ts:241-258`）は DB 削除が失敗しても catch して 200 を返すため、Clerk Dashboard 上は Succeeded と表示される
