### PR TITLE
fix(webhook): Clerk Webhook の DB 更新失敗を 5xx で返す

### DIFF
--- a/src/app/api/webhooks/clerk/route.ts
+++ b/src/app/api/webhooks/clerk/route.ts
@@ -213,16 +213,23 @@ export async function POST(request: Request) {
 							data: updateData,
 						});
 					} catch (error) {
-						// ユーザーが存在しない場合の特別処理
 						if (
 							error &&
 							typeof error === "object" &&
 							"code" in error &&
 							(error as { code?: string }).code === "P2025"
 						) {
-							// ユーザーが存在しない場合はスキップ
+							// 対象が存在しない = 更新すべき行が無い。成功として扱う
 						} else {
+							// 更新に失敗したまま 200 を返すと Clerk は成功として記録し、
+							// リトライも Dashboard の Failed 表示も発生しない。
+							// 結果として Clerk 側の変更 (メールアドレス・ユーザー名等) が
+							// DB へ反映されないまま乖離し続ける (issue #255)。
+							// user.deleted と同じく 5xx を返してリトライと可視化に載せる。
 							console.error(`ユーザー更新エラー: ${id}`, error);
+							return new NextResponse("Webhook Error: user update failed", {
+								status: 500,
+							});
 						}
 					}
 				}
@@ -244,16 +251,22 @@ export async function POST(request: Request) {
 						where: { clerkId: id },
 					});
 				} catch (error) {
-					// ユーザーが存在しない場合は警告のみ
 					if (
 						error &&
 						typeof error === "object" &&
 						"code" in error &&
 						(error as { code?: string }).code === "P2025"
 					) {
-						// ユーザーが既に削除されている場合はスキップ
+						// 対象が存在しない = 既に削除済み。冪等なので成功として扱う
 					} else {
+						// 削除に失敗したまま 200 を返すと Clerk は成功として記録し、
+						// リトライも Dashboard の Failed 表示も発生しない。
+						// 結果として DB に行が残り続け、後から一意制約違反(P2002)の
+						// 衝突相手になる (issue #255)。5xx を返してリトライと可視化に載せる。
 						console.error(`ユーザー削除エラー: ${id}`, error);
+						return new NextResponse("Webhook Error: user deletion failed", {
+							status: 500,
+						});
 					}
 				}
 				break;


### PR DESCRIPTION
## Summary

Clerk Webhook の `user.updated` / `user.deleted` ハンドラが、Prisma の失敗を握り潰して `200` を返していた問題を修正する。

Refs #255

## 問題

両ハンドラの catch が、`P2025` 以外のエラーを `console.error` に出すだけで処理を継続していた。

```ts
} catch (error) {
	if (error.code === "P2025") {
		// スキップ
	} else {
		console.error(`ユーザー削除エラー: ${id}`, error);   // ← ログのみ
	}
}
break;   // ← 200 を返す
```

**DB 操作が失敗しても Clerk には成功として応答する。** そのため以下が一切起きない。

- Clerk のリトライ
- Clerk Dashboard の Message Attempts に **Failed** として表示されること

失敗の痕跡は Vercel のサーバーログの 1 行だけになる。

## 実害（発生済み）

issue #248 の調査中、本番 DB の `User` 行数（5件）と Clerk Dashboard の Users（4件）を突合したところ、**Clerk 側で削除済みのアカウントに対応する行が 2 件残存**していた。

| DB `username` | Clerk Users に存在するか | 冒険ログ |
|---|---|---|
| `bojjiartdev` | **なし** | 0件 |
| `camoneart` | **なし** | 24件 |

`username="camoneart"` の行は `@unique` 制約下でその値を占有し続けていたため、**同じ値で新規作成しようとした際の一意制約違反（`P2002`）の衝突相手**になっていた。

この孤児行は以下のどこにも現れない。

| 確認手段 | 検知できるか |
|---|---|
| ブラウザの DevTools | できない（サーバー間通信のため） |
| Clerk Dashboard | **できない**（200 を返すので Succeeded と表示される） |
| Vercel のログ | `console.error` の 1 行のみ |
| **DB を直接数える** | **これでのみ検知できた** |

`user.updated` 側も同じ握り潰しにより、Clerk 側のメールアドレス・ユーザー名の変更が DB へ反映されないまま乖離し続ける。

## 変更内容

両ハンドラの catch を対称な形に揃える。

```ts
} catch (error) {
	if (error.code === "P2025") {
		// 対象が存在しない = 既に削除済み。冪等なので成功として扱う
	} else {
		// 削除に失敗したまま 200 を返すと Clerk は成功として記録し、
		// リトライも Dashboard の Failed 表示も発生しない。
		// 結果として DB に行が残り続け、後から一意制約違反(P2002)の
		// 衝突相手になる (issue #255)。5xx を返してリトライと可視化に載せる。
		console.error(`ユーザー削除エラー: ${id}`, error);
		return new NextResponse("Webhook Error: user deletion failed", {
			status: 500,
		});
	}
}
```

| エラー | 変更前 | 変更後 |
|---|---|---|
| 成功 | 200 | **200**（変化なし） |
| `P2025`（対象が存在しない） | 200 | **200**（変化なし。冪等な正常系） |
| **それ以外** | **200** | **500** |

### 既存パターンへの追従

`500` を返す形は同ファイルの既存のエラー処理と同じであり、新しい規約は持ち込まない。

| 行 | 状況 | ステータス |
|---|---|---|
| 108 | 署名シークレット未設定 | 500 |
| 122 | svix ヘッダー欠落 | 4xx |
| 141 | 署名が不正 | 4xx |
| 159 | メールアドレス取得失敗 | 4xx |
| 236 | ID 欠落 | 4xx |

また `user.created` 経路（`ensureUserExists`）は既に `throw error` で例外を伝播させ、外側の catch が 500 を返す形になっている。本 PR で `user.updated` / `user.deleted` をこれに揃える。

## 影響範囲

**アプリ側への影響はない。**

`src/` 全域を検索したが、`/api/webhooks/clerk` を fetch している箇所は存在しない（ヒットしたのはコード内のコメント参照のみ）。このエンドポイントは Clerk のサーバーからのみ呼ばれる。

UI に表示されるエラーメッセージは `/connection` や `/dashboard` 側が生成しており、本ファイルは関与しない。

## Test Plan

- [x] `pnpm lint` — **exit 0**（error 0 / warning 12）
- [x] `pnpm format:check` — **exit 0**
- [x] `pnpm exec tsc --noEmit` — **exit 0**
- [x] `pnpm test:run` — **52 passed (7 files)**
- [x] `pnpm build` — **exit 0**

## Breaking Changes

なし。成功時と `P2025` の応答は変わらない。変わるのは DB 操作が失敗したときの応答のみ。

## 検証の限界

**実際に DB 操作を失敗させた状態での動作は未検証。** Clerk が実際にリトライするか、Dashboard に Failed として表示されるかは確認していない。再現には DB を意図的に停止させる必要があり、本番データを使わずに再現する手段が現状ない（issue #248 の環境分離が済めば可能になる）。

分岐条件は既存の `P2025` 判定をそのまま使用しており、返す 500 も同ファイルの既存パターンと同一。

## 既存の孤児行について

本 PR とは別に、本調査で見つかった孤児行 2 件（`bojjiartdev` / `camoneart`）は既に削除済み。

| | 削除前 | 削除後 |
|---|---|---|
| `User` | 5行 | **3行** |
| `AdventureLog` | 50件 | **26件** |

削除は事前にバックアップを取得し、トランザクション内で件数を検証してから実行した。

なお **Clerk に存在するが DB 行が無いユーザー**（`aoymdev@gmail.com`）が 1 件あり、こちらは未対応。issue #255 に記録している。
